### PR TITLE
Fix for issue 13, Expressions as variables causes InvalidCastException

### DIFF
--- a/src/Flee.NetStandard/PublicTypes/VariableCollection.cs
+++ b/src/Flee.NetStandard/PublicTypes/VariableCollection.cs
@@ -1,27 +1,26 @@
-﻿
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics;
-using System.Reflection;
-using System.ComponentModel;
-using Flee.InternalTypes;
-using Flee.PublicTypes;
+﻿using Flee.InternalTypes;
 using Flee.Resources;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
 
 namespace Flee.PublicTypes
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public sealed class VariableCollection : IDictionary<string, object>
     {
         private IDictionary<string, IVariable> _myVariables;
         private readonly ExpressionContext _myContext;
+
         public event EventHandler<ResolveVariableTypeEventArgs> ResolveVariableType;
+
         public event EventHandler<ResolveVariableValueEventArgs> ResolveVariableValue;
+
         public event EventHandler<ResolveFunctionEventArgs> ResolveFunction;
+
         public event EventHandler<InvokeFunctionEventArgs> InvokeFunction;
 
         internal VariableCollection(ExpressionContext context)
@@ -32,6 +31,7 @@ namespace Flee.PublicTypes
         }
 
         #region "Methods - Non Public"
+
         private void HookOptions()
         {
             _myContext.Options.CaseSensitiveChanged += OnOptionsCaseSensitiveChanged;
@@ -118,10 +118,7 @@ namespace Flee.PublicTypes
                 options = expression.Context.Options;
                 // Get its result type
                 variableValueType = options.ResultType;
-            }
 
-            if (expression != null)
-            {
                 // Create a variable that wraps the expression
 
                 if (options.IsGeneric == false)
@@ -215,9 +212,11 @@ namespace Flee.PublicTypes
 
             return dict;
         }
-        #endregion
+
+        #endregion "Methods - Non Public"
 
         #region "Methods - Public"
+
         public Type GetVariableType(string name)
         {
             IVariable v = this.GetVariable(name, true);
@@ -231,18 +230,15 @@ namespace Flee.PublicTypes
 
         public T GetVariableValueInternal<T>(string name)
         {
-            //TODO:@muhammet burada vb de ref vardı c# karşılık yap.
-            GenericVariable<T> result = new GenericVariable<T>();
-            if (_myVariables.ContainsKey(name))
+            if (_myVariables.TryGetValue(name, out IVariable variable))
             {
-                result.ValueAsObject = _myVariables[name].ValueAsObject;
-                return (T)result.GetValue();
+                if (variable is IGenericVariable<T> generic)
+                {
+                    return (T)generic.GetValue();
+                }
             }
-            //if (MyVariables.TryGetValue(name, out v))
-            //{
-            //    return v.GetValue();
-            //}
 
+            GenericVariable<T> result = new GenericVariable<T>();
             GenericVariable<T> vTemp = new GenericVariable<T>();
             ResolveVariableValueEventArgs args = new ResolveVariableValueEventArgs(name, typeof(T));
             ResolveVariableValue?.Invoke(this, args);
@@ -276,13 +272,16 @@ namespace Flee.PublicTypes
 
             return ReturnGenericValue<T>(result);
         }
-        #endregion
+
+        #endregion "Methods - Public"
 
         #region "IDictionary Implementation"
+
         private void Add1(System.Collections.Generic.KeyValuePair<string, object> item)
         {
             this.Add(item.Key, item.Value);
         }
+
         void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>.Add(System.Collections.Generic.KeyValuePair<string, object> item)
         {
             Add1(item);
@@ -297,6 +296,7 @@ namespace Flee.PublicTypes
         {
             return this.ContainsKey(item.Key);
         }
+
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>.Contains(System.Collections.Generic.KeyValuePair<string, object> item)
         {
             return Contains1(item);
@@ -313,6 +313,7 @@ namespace Flee.PublicTypes
         {
             return this.Remove(item.Key);
         }
+
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>.Remove(System.Collections.Generic.KeyValuePair<string, object> item)
         {
             return Remove1(item);
@@ -352,6 +353,7 @@ namespace Flee.PublicTypes
         {
             return this.GetEnumerator();
         }
+
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return GetEnumerator1();
@@ -398,6 +400,7 @@ namespace Flee.PublicTypes
         {
             CopyTo(array, arrayIndex);
         }
-        #endregion
+
+        #endregion "IDictionary Implementation"
     }
 }

--- a/src/Flee/PublicTypes/VariableCollection.cs
+++ b/src/Flee/PublicTypes/VariableCollection.cs
@@ -1,27 +1,26 @@
-﻿
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics;
-using System.Reflection;
-using System.ComponentModel;
-using Flee.InternalTypes;
-using Flee.PublicTypes;
+﻿using Flee.InternalTypes;
 using Flee.Resources;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
 
 namespace Flee.PublicTypes
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public sealed class VariableCollection : IDictionary<string, object>
     {
         private IDictionary<string, IVariable> _myVariables;
         private readonly ExpressionContext _myContext;
+
         public event EventHandler<ResolveVariableTypeEventArgs> ResolveVariableType;
+
         public event EventHandler<ResolveVariableValueEventArgs> ResolveVariableValue;
+
         public event EventHandler<ResolveFunctionEventArgs> ResolveFunction;
+
         public event EventHandler<InvokeFunctionEventArgs> InvokeFunction;
 
         internal VariableCollection(ExpressionContext context)
@@ -32,6 +31,7 @@ namespace Flee.PublicTypes
         }
 
         #region "Methods - Non Public"
+
         private void HookOptions()
         {
             _myContext.Options.CaseSensitiveChanged += OnOptionsCaseSensitiveChanged;
@@ -118,10 +118,7 @@ namespace Flee.PublicTypes
                 options = expression.Context.Options;
                 // Get its result type
                 variableValueType = options.ResultType;
-            }
 
-            if (expression != null)
-            {
                 // Create a variable that wraps the expression
 
                 if (options.IsGeneric == false)
@@ -215,9 +212,11 @@ namespace Flee.PublicTypes
 
             return dict;
         }
-        #endregion
+
+        #endregion "Methods - Non Public"
 
         #region "Methods - Public"
+
         public Type GetVariableType(string name)
         {
             IVariable v = this.GetVariable(name, true);
@@ -231,18 +230,15 @@ namespace Flee.PublicTypes
 
         public T GetVariableValueInternal<T>(string name)
         {
-            //TODO:@muhammet burada vb de ref vardı c# karşılık yap.
-            GenericVariable<T> result = new GenericVariable<T>();
-            if (_myVariables.ContainsKey(name))
+            if (_myVariables.TryGetValue(name, out IVariable variable))
             {
-                result.ValueAsObject = _myVariables[name].ValueAsObject;
-                return (T)result.GetValue();
+                if (variable is IGenericVariable<T> generic)
+                {
+                    return (T)generic.GetValue();
+                }
             }
-            //if (MyVariables.TryGetValue(name, out v))
-            //{
-            //    return v.GetValue();
-            //}
 
+            GenericVariable<T> result = new GenericVariable<T>();
             GenericVariable<T> vTemp = new GenericVariable<T>();
             ResolveVariableValueEventArgs args = new ResolveVariableValueEventArgs(name, typeof(T));
             ResolveVariableValue?.Invoke(this, args);
@@ -276,13 +272,16 @@ namespace Flee.PublicTypes
 
             return ReturnGenericValue<T>(result);
         }
-        #endregion
+
+        #endregion "Methods - Public"
 
         #region "IDictionary Implementation"
+
         private void Add1(System.Collections.Generic.KeyValuePair<string, object> item)
         {
             this.Add(item.Key, item.Value);
         }
+
         void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>.Add(System.Collections.Generic.KeyValuePair<string, object> item)
         {
             Add1(item);
@@ -297,6 +296,7 @@ namespace Flee.PublicTypes
         {
             return this.ContainsKey(item.Key);
         }
+
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>.Contains(System.Collections.Generic.KeyValuePair<string, object> item)
         {
             return Contains1(item);
@@ -313,6 +313,7 @@ namespace Flee.PublicTypes
         {
             return this.Remove(item.Key);
         }
+
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>.Remove(System.Collections.Generic.KeyValuePair<string, object> item)
         {
             return Remove1(item);
@@ -352,6 +353,7 @@ namespace Flee.PublicTypes
         {
             return this.GetEnumerator();
         }
+
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return GetEnumerator1();
@@ -398,6 +400,7 @@ namespace Flee.PublicTypes
         {
             CopyTo(array, arrayIndex);
         }
-        #endregion
+
+        #endregion "IDictionary Implementation"
     }
 }

--- a/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
+++ b/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Flee.PublicTypes;
+
+namespace ExpressionBuildingTest
+{
+    [TestClass]
+    public class ExpressionBuildingTest
+    {
+        [TestMethod]
+        public void ExpressionsAsVariables()
+        {
+            ExpressionContext context = new ExpressionContext();
+            context.Imports.AddType(typeof(Math));
+            context.Variables.Add("a", 3.14);
+            IDynamicExpression e1 = context.CompileDynamic("cos(a) ^ 2");
+
+            context = new ExpressionContext();
+            context.Imports.AddType(typeof(Math));
+            context.Variables.Add("a", 3.14);
+
+            IDynamicExpression e2 = context.CompileDynamic("sin(a) ^ 2");
+
+            // Use the two expressions as variables in another expression
+            context = new ExpressionContext();
+            context.Variables.Add("a", e1);
+            context.Variables.Add("b", e2);
+            IDynamicExpression e = context.CompileDynamic("a + b");
+
+            Console.WriteLine(e.Evaluate());
+        }
+    }
+}

--- a/test/Flee.Test/Flee.Test.csproj
+++ b/test/Flee.Test/Flee.Test.csproj
@@ -39,9 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flee, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flee.1.0.3\lib\net461\Flee.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -57,6 +54,7 @@
   <ItemGroup>
     <Compile Include="CalcEngineTests\CalcEngineTestFixture.cs" />
     <Compile Include="CalcEngineTests\SimpleCalcEngineTests.cs" />
+    <Compile Include="ExpressionTests\ExpressionBuildingTest.cs" />
     <Compile Include="ExpressionTests\Benchmarks.cs" />
     <Compile Include="ExpressionTests\Core.cs" />
     <Compile Include="Infrastructure\Core.cs" />
@@ -73,6 +71,12 @@
     <Content Include="TestScripts\SimpleCalcEngineTests.txt" />
     <Content Include="TestScripts\ValidCasts.txt" />
     <Content Include="TestScripts\ValidExpressions.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Flee.NetStandard\Flee.NetStandard.csproj">
+      <Project>{c5f12a89-4ebc-43f4-8b63-d4ce3fdc6faf}</Project>
+      <Name>Flee.NetStandard</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/Flee.Test/packages.config
+++ b/test/Flee.Test/packages.config
@@ -4,4 +4,5 @@
   <package id="MSTest.TestAdapter" version="1.1.11" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.1.11" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Just modified the VariableCollection.GetVariableValueInternal() variable to run .GetValue() on the correct Type.