### PR TITLE
Fixed broken null check

### DIFF
--- a/src/Flee.NetStandard/Parsing/Expression.grammar
+++ b/src/Flee.NetStandard/Parsing/Expression.grammar
@@ -27,8 +27,8 @@ LICENSE = "This library is free software; you can redistribute it and/or
 COPYRIGHT = "Copyright (c) 2007 Eugene Ciloci"
 
 %tokens%
-ADD			     = "+"
-SUB                          = "-"
+ADD				= "+"
+SUB             = "-"
 MUL                          = "*"
 DIV                          = "/"
 POWER                        = "^"
@@ -64,7 +64,7 @@ TRUE			     = "True"
 FALSE			     = "False"
 IDENTIFIER		     = <<[a-z_]\w*>>
 HEX_LITERAL		     = <<0x[0-9a-f]+(u|l|ul|lu)?>>
-NULL_LITERAL                 = "null"
+NULL_LITERAL        = "null"
 TIMESPAN			= <<##(\d+\.)?\d{2}:\d{2}(:\d{2}(\.\d{1,7})?)?#>>
 DATETIME			= <<#[^#]+#>>
 

--- a/src/Flee.NetStandard/Parsing/ExpressionConstants.cs
+++ b/src/Flee.NetStandard/Parsing/ExpressionConstants.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-
-namespace Flee.Parsing
+﻿namespace Flee.Parsing
 {
     ///<remarks>
     /// An enumeration with token and production node
@@ -43,9 +38,9 @@ namespace Flee.Parsing
         CHAR_LITERAL = 1031,
         TRUE = 1032,
         FALSE = 1033,
-        IDENTIFIER = 1034,
+        NULL_LITERAL = 1034,
         HEX_LITERAL = 1035,
-        NULL_LITERAL = 1036,
+        IDENTIFIER = 1036,
         TIMESPAN = 1037,
         DATETIME = 1038,
         IF = 1039,

--- a/src/Flee/Parsing/ExpressionConstants.cs
+++ b/src/Flee/Parsing/ExpressionConstants.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-
-namespace Flee.Parsing
+﻿namespace Flee.Parsing
 {
     ///<remarks>
     /// An enumeration with token and production node
@@ -43,9 +38,9 @@ namespace Flee.Parsing
         CHAR_LITERAL = 1031,
         TRUE = 1032,
         FALSE = 1033,
-        IDENTIFIER = 1034,
+        NULL_LITERAL = 1034,
         HEX_LITERAL = 1035,
-        NULL_LITERAL = 1036,
+        IDENTIFIER = 1036,
         TIMESPAN = 1037,
         DATETIME = 1038,
         IF = 1039,

--- a/test/Flee.Test/CalcEngineTests/CalcEngineTestFixture.cs
+++ b/test/Flee.Test/CalcEngineTests/CalcEngineTestFixture.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using Flee.CalcEngine.PublicTypes;
+﻿using Flee.CalcEngine.PublicTypes;
 using Flee.PublicTypes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
+using System.Collections.Generic;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace Flee.Test.CalcEngineTests
@@ -129,8 +128,8 @@ namespace Flee.Test.CalcEngineTests
 
             ce.Add("x", "100 >> 2", context);
             ce.Recalculate("x");
-            var result = ce.GetResult<bool>("x");
-            Assert.IsTrue(result);
+            var result = ce.GetResult<int>("x");
+            Assert.AreEqual(25, result);
         }
 
         [Test]
@@ -163,7 +162,7 @@ namespace Flee.Test.CalcEngineTests
             ce.Add("b", "a + y", context);
             ce.Add("c", "b * 2", context);
             ce.Recalculate("a");
-            variables.Add("y", 222);
+            variables["y"] = 222;
             ce.Recalculate("b");
             var result = ce.GetResult<int>("c");
             Assert.AreEqual(((100 * 2) + 222) * 2, result);
@@ -180,7 +179,7 @@ namespace Flee.Test.CalcEngineTests
             ce.Add("a", "x * 2", context);
             variables.Add("y", 1);
             ce.Add("b", "a + y + b", context);
-            ce.Recalculate("a");
+            Assert.ThrowsException<CircularReferenceException>(() => { ce.Recalculate("a"); });
         }
 
         [Test]
@@ -201,9 +200,6 @@ namespace Flee.Test.CalcEngineTests
             foreach (var expressionVariable in expressionVariables.Keys)
                 vars[expressionVariable] = expressionVariables[expressionVariable];
             var a = dynamicExpression.Evaluate();
-
-
-
 
             //ExpressionContext context = new ExpressionContext();
             //VariableCollection variables = context.Variables;

--- a/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
+++ b/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
@@ -39,5 +39,15 @@ namespace ExpressionBuildingTest
 
             Assert.IsFalse((bool)e1.Evaluate());
         }
+
+        [TestMethod]
+        public void NullIsNullCheck()
+        {
+            ExpressionContext context = new ExpressionContext();
+            context.Variables.Add("a", "stringObject");
+            IDynamicExpression e1 = context.CompileDynamic("null = null");
+
+            Assert.IsTrue((bool)e1.Evaluate());
+        }
     }
 }

--- a/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
+++ b/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
@@ -29,5 +29,15 @@ namespace ExpressionBuildingTest
 
             Console.WriteLine(e.Evaluate());
         }
+
+        [TestMethod]
+        public void NullCheck()
+        {
+            ExpressionContext context = new ExpressionContext();
+            context.Variables.Add("a", "stringObject");
+            IDynamicExpression e1 = context.CompileDynamic("a = null");
+
+            Assert.IsFalse((bool)e1.Evaluate());
+        }
     }
 }

--- a/test/Flee.Test/Flee.Test.csproj
+++ b/test/Flee.Test/Flee.Test.csproj
@@ -39,9 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flee, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flee.1.0.5\lib\net461\Flee.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -74,6 +71,12 @@
     <Content Include="TestScripts\SimpleCalcEngineTests.txt" />
     <Content Include="TestScripts\ValidCasts.txt" />
     <Content Include="TestScripts\ValidExpressions.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Flee.NetStandard\Flee.NetStandard.csproj">
+      <Project>{c5f12a89-4ebc-43f4-8b63-d4ce3fdc6faf}</Project>
+      <Name>Flee.NetStandard</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Fix for null check is broken issue #6. The vb and c# parser compares token differently. 
VB only checks if length of token is longer between tokenmatchers while c# version also considers token id. 
VB
`if re.Match() AndAlso re.GetMatchedLength() > bestLength Then....`
c#
`else if (this._length == length && this._pattern.Id > pattern.Id)`
To fix bug i swapped id of null and identifier token to prevent the parser to interpret `null` is a variable.