### PR TITLE
Flee fails to parse if formula

### DIFF
--- a/src/Flee.Net45/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/TokenMatch.cs
+++ b/src/Flee.Net45/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/TokenMatch.cs
@@ -8,8 +8,7 @@ namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
 {
     /**
      * The token match status. This class contains logic to ensure that
-     * only the longest match is considered. It also prefers lower token
-     * pattern identifiers if two matches have the same length.
+     * only the longest match is considered.
      */
     internal class TokenMatch
     {
@@ -29,11 +28,6 @@ namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
         public void Update(int length, TokenPattern pattern)
         {
             if (this._length < length)
-            {
-                this._length = length;
-                this._pattern = pattern;
-            }
-            else if (this._length == length && this._pattern.Id > pattern.Id)
             {
                 this._length = length;
                 this._pattern = pattern;

--- a/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/TokenMatch.cs
+++ b/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/TokenMatch.cs
@@ -8,8 +8,7 @@ namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
 {
     /**
      * The token match status. This class contains logic to ensure that
-     * only the longest match is considered. It also prefers lower token
-     * pattern identifiers if two matches have the same length.
+     * only the longest match is considered.
      */
     internal class TokenMatch
     {
@@ -29,11 +28,6 @@ namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
         public void Update(int length, TokenPattern pattern)
         {
             if (this._length < length)
-            {
-                this._length = length;
-                this._pattern = pattern;
-            }
-            else if (this._length == length && this._pattern.Id > pattern.Id)
             {
                 this._length = length;
                 this._pattern = pattern;

--- a/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
+++ b/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
@@ -30,6 +30,34 @@ namespace ExpressionBuildingTest
             Console.WriteLine(e.Evaluate());
         }
 
+
+        [TestMethod]
+        public void Test_IfExpression_enUS()
+        {
+            ExpressionContext context = new ExpressionContext();
+            context.Options.ParseCulture = new System.Globalization.CultureInfo("en-US");
+
+            int resultWhenTrue = 3;
+
+            IDynamicExpression e = context.CompileDynamic("if(1<2, 3, 4)");
+
+            Assert.IsTrue((int)e.Evaluate() == resultWhenTrue);
+        }
+
+        [TestMethod]
+        public void Test_IfExpression_fiFI()
+        {
+            ExpressionContext context = new ExpressionContext();
+            context.Imports.AddType(typeof(Math));
+            context.Options.ParseCulture = new System.Globalization.CultureInfo("fi-FI");
+
+            int resultWhenFalse = 4;
+
+            IDynamicExpression e = context.CompileDynamic("if(1>2; 3; 4)");
+
+            Assert.IsTrue((int)e.Evaluate() == resultWhenFalse);
+        }
+
         [TestMethod]
         public void NullCheck()
         {


### PR DESCRIPTION
Original implementation does not make any identifier prefers if multiple matches have same match length. This breaks the "IF" formula as it will always be resolved as "IDENTIFIER" because it's having smaller pattern ID.

Other way to fix this would be to change pattern IDs and leave the implementation as it is.