### PR TITLE
Update Arithmetic.cs

### DIFF
--- a/src/Flee.Net45/ExpressionElements/Arithmetic.cs
+++ b/src/Flee.Net45/ExpressionElements/Arithmetic.cs
@@ -316,7 +316,7 @@ namespace Flee.ExpressionElements
         {
             get
             {
-                if (_myOperation != BinaryArithmeticOperation.Power)
+                if (_myOperation != BinaryArithmeticOperation.Power || !(MyRightChild is Int32LiteralElement))
                 {
                     return false;
                 }


### PR DESCRIPTION
Solves a InvalidCastException when the exponent isn't an integer.