### PR TITLE
add support for extension methods

### DIFF
--- a/src/Flee.Net45/ExpressionElements/MemberElements/FunctionCall.cs
+++ b/src/Flee.Net45/ExpressionElements/MemberElements/FunctionCall.cs
@@ -52,7 +52,7 @@ namespace Flee.ExpressionElements.MemberElements
 
             if (methods.Count > 0)
             {
-                // More than one method exists with this name			
+                // More than one method exists with this name
                 this.BindToMethod(methods, MyPrevious, argTypes);
                 return;
             }
@@ -119,7 +119,7 @@ namespace Flee.ExpressionElements.MemberElements
 
             foreach (CustomMethodInfo cmi in arr)
             {
-                if (cmi.IsMatch(argTypes) == true)
+                if (cmi.IsMatch(argTypes, previous, MyContext) == true)
                 {
                     customInfos.Add(cmi);
                 }
@@ -333,7 +333,14 @@ namespace Flee.ExpressionElements.MemberElements
             // Emit either a regular or paramArray call
             if (_myTargetMethodInfo.IsParamArray == false)
             {
-                this.EmitRegularFunctionInternal(parameters, elements, ilg, services);
+                if (_myTargetMethodInfo.IsExtensionMethod == false)
+                {
+                    this.EmitRegularFunctionInternal(parameters, elements, ilg, services);
+                }
+                else
+                {
+                    this.EmitExtensionFunctionInternal(parameters, elements, ilg, services);
+                }
             }
             else
             {
@@ -366,8 +373,35 @@ namespace Flee.ExpressionElements.MemberElements
         }
 
         /// <summary>
+        ///  Emit the arguments to a regular method call
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <param name="elements"></param>
+        /// <param name="ilg"></param>
+        /// <param name="services"></param>
+        private void EmitExtensionFunctionInternal(ParameterInfo[] parameters, ExpressionElement[] elements, FleeILGenerator ilg, IServiceProvider services)
+        {
+            Debug.Assert(parameters.Length == elements.Length + 1, "argument count mismatch");
+
+            if (MyPrevious == null)
+            {
+                EmitLoadOwner(ilg);
+            }
+
+            // Emit each element and any required conversions to the actual parameter type
+            for (int i = 0; i < parameters.Length - 1; i++)
+            {
+                var element = elements[i];
+                var pi = parameters[i + 1];
+                element.Emit(ilg, services);
+                bool success = ImplicitConverter.EmitImplicitConvert(element.ResultType, pi.ParameterType, ilg);
+                Debug.Assert(success, "conversion failed");
+            }
+        }
+
+        /// <summary>
         /// The method info we will be calling
-        /// </summary>	
+        /// </summary>
         private MethodInfo Method => _myTargetMethodInfo.Target;
 
         public override Type ResultType
@@ -390,5 +424,7 @@ namespace Flee.ExpressionElements.MemberElements
         protected override bool IsPublic => this.Method.IsPublic;
 
         public override bool IsStatic => this.Method.IsStatic;
+
+        public override bool IsExtensionMethod => this._myTargetMethodInfo.IsExtensionMethod;
     }
 }

--- a/src/Flee.Net45/ExpressionElements/MemberElements/FunctionCall.cs
+++ b/src/Flee.Net45/ExpressionElements/MemberElements/FunctionCall.cs
@@ -145,10 +145,12 @@ namespace Flee.ExpressionElements.MemberElements
         /// <param name="argTypes"></param>
         private void ResolveOverloads(CustomMethodInfo[] infos, MemberElement previous, Type[] argTypes)
         {
+            var ownerType = previous?.ResultType ?? MyContext?.ExpressionOwner.GetType();
+
             // Compute a score for each candidate
             foreach (CustomMethodInfo cmi in infos)
             {
-                cmi.ComputeScore(argTypes);
+                cmi.ComputeScore(argTypes, ownerType);
             }
 
             // Sort array from best to worst matches

--- a/src/Flee.Net45/Flee.Net45.csproj
+++ b/src/Flee.Net45/Flee.Net45.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>flee.pfx</AssemblyOriginatorKeyFile>

--- a/src/Flee.Net45/InternalTypes/Miscellaneous.cs
+++ b/src/Flee.Net45/InternalTypes/Miscellaneous.cs
@@ -182,7 +182,7 @@ namespace Flee.InternalTypes
             _myTarget = target;
         }
 
-        public void ComputeScore(Type[] argTypes)
+        public void ComputeScore(Type[] argTypes, Type ownerType)
         {
             ParameterInfo[] @params = _myTarget.GetParameters();
 
@@ -192,7 +192,7 @@ namespace Flee.InternalTypes
             }
             else if (@params.Length == 1 && argTypes.Length == 0) // extension method without parameter support -> prefer members
             {
-                _myScore = 0.1F;
+                _myScore = ownerType == null ? 0.1F : 0.1F + this.ComputeScoreInternal(@params, new [] { ownerType });
             }
             else if (IsParamArray == true)
             {

--- a/src/Flee.NetStandard20/ExpressionElements/MemberElements/FunctionCall.cs
+++ b/src/Flee.NetStandard20/ExpressionElements/MemberElements/FunctionCall.cs
@@ -52,7 +52,7 @@ namespace Flee.ExpressionElements.MemberElements
 
             if (methods.Count > 0)
             {
-                // More than one method exists with this name			
+                // More than one method exists with this name
                 this.BindToMethod(methods, MyPrevious, argTypes);
                 return;
             }
@@ -119,7 +119,7 @@ namespace Flee.ExpressionElements.MemberElements
 
             foreach (CustomMethodInfo cmi in arr)
             {
-                if (cmi.IsMatch(argTypes) == true)
+                if (cmi.IsMatch(argTypes, previous, MyContext) == true)
                 {
                     customInfos.Add(cmi);
                 }
@@ -333,7 +333,14 @@ namespace Flee.ExpressionElements.MemberElements
             // Emit either a regular or paramArray call
             if (_myTargetMethodInfo.IsParamArray == false)
             {
-                this.EmitRegularFunctionInternal(parameters, elements, ilg, services);
+                if (_myTargetMethodInfo.IsExtensionMethod == false)
+                {
+                    this.EmitRegularFunctionInternal(parameters, elements, ilg, services);
+                }
+                else
+                {
+                    this.EmitExtensionFunctionInternal(parameters, elements, ilg, services);
+                }
             }
             else
             {
@@ -366,8 +373,35 @@ namespace Flee.ExpressionElements.MemberElements
         }
 
         /// <summary>
+        ///  Emit the arguments to a regular method call
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <param name="elements"></param>
+        /// <param name="ilg"></param>
+        /// <param name="services"></param>
+        private void EmitExtensionFunctionInternal(ParameterInfo[] parameters, ExpressionElement[] elements, FleeILGenerator ilg, IServiceProvider services)
+        {
+            Debug.Assert(parameters.Length == elements.Length + 1, "argument count mismatch");
+
+            if (MyPrevious == null)
+            {
+                EmitLoadOwner(ilg);
+            }
+
+            // Emit each element and any required conversions to the actual parameter type
+            for (int i = 0; i < parameters.Length - 1; i++)
+            {
+                var element = elements[i];
+                var pi = parameters[i + 1];
+                element.Emit(ilg, services);
+                bool success = ImplicitConverter.EmitImplicitConvert(element.ResultType, pi.ParameterType, ilg);
+                Debug.Assert(success, "conversion failed");
+            }
+        }
+
+        /// <summary>
         /// The method info we will be calling
-        /// </summary>	
+        /// </summary>
         private MethodInfo Method => _myTargetMethodInfo.Target;
 
         public override Type ResultType
@@ -390,5 +424,7 @@ namespace Flee.ExpressionElements.MemberElements
         protected override bool IsPublic => this.Method.IsPublic;
 
         public override bool IsStatic => this.Method.IsStatic;
+
+        public override bool IsExtensionMethod => this._myTargetMethodInfo.IsExtensionMethod;
     }
 }

--- a/src/Flee.NetStandard20/ExpressionElements/MemberElements/FunctionCall.cs
+++ b/src/Flee.NetStandard20/ExpressionElements/MemberElements/FunctionCall.cs
@@ -145,10 +145,12 @@ namespace Flee.ExpressionElements.MemberElements
         /// <param name="argTypes"></param>
         private void ResolveOverloads(CustomMethodInfo[] infos, MemberElement previous, Type[] argTypes)
         {
+            var ownerType = previous?.ResultType ?? MyContext?.ExpressionOwner.GetType();
+
             // Compute a score for each candidate
             foreach (CustomMethodInfo cmi in infos)
             {
-                cmi.ComputeScore(argTypes);
+                cmi.ComputeScore(argTypes, ownerType);
             }
 
             // Sort array from best to worst matches

--- a/src/Flee.NetStandard20/Flee.NetStandard20.csproj
+++ b/src/Flee.NetStandard20/Flee.NetStandard20.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Flee</RootNamespace>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>flee.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
   </PropertyGroup>

--- a/src/Flee.NetStandard20/InternalTypes/Miscellaneous.cs
+++ b/src/Flee.NetStandard20/InternalTypes/Miscellaneous.cs
@@ -182,7 +182,7 @@ namespace Flee.InternalTypes
             _myTarget = target;
         }
 
-        public void ComputeScore(Type[] argTypes)
+        public void ComputeScore(Type[] argTypes, Type ownerType)
         {
             ParameterInfo[] @params = _myTarget.GetParameters();
 
@@ -192,7 +192,7 @@ namespace Flee.InternalTypes
             }
             else if (@params.Length == 1 && argTypes.Length == 0) // extension method without parameter support -> prefer members
             {
-                _myScore = 0.1F;
+                _myScore = ownerType == null ? 0.1F : 0.1F + this.ComputeScoreInternal(@params, new [] { ownerType });
             }
             else if (IsParamArray == true)
             {

--- a/test/Flee.Test/ExpressionTests/ExtensionMethodTest.cs
+++ b/test/Flee.Test/ExpressionTests/ExtensionMethodTest.cs
@@ -1,13 +1,22 @@
-﻿using Flee.PublicTypes;
-using Flee.Test.ExpressionTests.ExtensionMethodTestData;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace Flee.Test.ExpressionTests
+﻿namespace Flee.OtherTests
 {
+    using Flee.PublicTypes;
+    using Flee.Test.Infrastructure;
+    using Flee.OtherTests.ExtensionMethodTestData;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     /// <summary>The extension method test.</summary>
     [TestClass]
-    public class ExtensionMethodTest : Core
+    public class ExtensionMethodTest : ExpressionTests
     {
+        [TestMethod]
+        public void TestExtensionMethodAsMethodCallOnOwner()
+        {
+            var result = GetExpressionContext().CompileDynamic("SayHello(Sub)").Evaluate();
+            Assert.AreEqual("Hello as well, SubWorld", result);
+        }
+
         [TestMethod]
         public void TestExtensionMethodCallOnOwner()
         {
@@ -19,7 +28,7 @@ namespace Flee.Test.ExpressionTests
         public void TestExtensionMethodCallOnProperty()
         {
             var result = GetExpressionContext().CompileDynamic("Sub.SayHello()").Evaluate();
-            Assert.AreEqual("Hello SubWorld", result);
+            Assert.AreEqual("Hello as well, SubWorld", result);
         }
 
         [TestMethod]
@@ -47,7 +56,7 @@ namespace Flee.Test.ExpressionTests
         public void TestExtensionMethodCallOnPropertyWithArguments()
         {
             var result = GetExpressionContext().CompileDynamic("Sub.SayHello(\"!!!\")").Evaluate();
-            Assert.AreEqual("Hello SubWorld!!!", result);
+            Assert.AreEqual("Hello as well, SubWorld!!!", result);
         }
 
         [TestMethod]
@@ -61,7 +70,7 @@ namespace Flee.Test.ExpressionTests
         public void TestExtensionMethodCallOnPropertyWithArgumentsOnOverload()
         {
             var result = GetExpressionContext().CompileDynamic("Sub.SayHello(\"!!!\")").Evaluate();
-            Assert.AreEqual("Hello SubWorld!!!", result);
+            Assert.AreEqual("Hello as well, SubWorld!!!", result);
         }
 
         private static ExpressionContext GetExpressionContext()

--- a/test/Flee.Test/ExpressionTests/ExtensionMethodTest.cs
+++ b/test/Flee.Test/ExpressionTests/ExtensionMethodTest.cs
@@ -1,0 +1,75 @@
+﻿using Flee.PublicTypes;
+using Flee.Test.ExpressionTests.ExtensionMethodTestData;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Flee.Test.ExpressionTests
+{
+    /// <summary>The extension method test.</summary>
+    [TestClass]
+    public class ExtensionMethodTest : Core
+    {
+        [TestMethod]
+        public void TestExtensionMethodCallOnOwner()
+        {
+            var result = GetExpressionContext().CompileDynamic("SayHello()").Evaluate();
+            Assert.AreEqual("Hello World", result);
+        }
+
+        [TestMethod]
+        public void TestExtensionMethodCallOnProperty()
+        {
+            var result = GetExpressionContext().CompileDynamic("Sub.SayHello()").Evaluate();
+            Assert.AreEqual("Hello SubWorld", result);
+        }
+
+        [TestMethod]
+        public void TestExtensionMethodCallOnOwnerWithArguments()
+        {
+            var result = GetExpressionContext().CompileDynamic("SayHello(\"!!!\")").Evaluate();
+            Assert.AreEqual("Hello World!!!", result);
+        }
+
+        [TestMethod]
+        public void TestExtensionMethodCallOnOwnerWithArgumentsOnOverload()
+        {
+            var result = GetExpressionContext().CompileDynamic("SayHello(true)").Evaluate();
+            Assert.AreEqual("Hello dear World", result);
+        }
+
+        [TestMethod]
+        public void TestExtensionMethodCallOnOwnerWithArgumentsOnClassOverload()
+        {
+            var result = GetExpressionContext().CompileDynamic("SayHello(2)").Evaluate();
+            Assert.AreEqual("hello hello World", result);
+        }
+
+        [TestMethod]
+        public void TestExtensionMethodCallOnPropertyWithArguments()
+        {
+            var result = GetExpressionContext().CompileDynamic("Sub.SayHello(\"!!!\")").Evaluate();
+            Assert.AreEqual("Hello SubWorld!!!", result);
+        }
+
+        [TestMethod]
+        public void TestExtensionMethodCallOnPropertyWithArgumentsOnClassOverload()
+        {
+            var result = GetExpressionContext().CompileDynamic("Sub.SayHello(2)").Evaluate();
+            Assert.AreEqual("hello hello SubWorld", result);
+        }
+
+        [TestMethod]
+        public void TestExtensionMethodCallOnPropertyWithArgumentsOnOverload()
+        {
+            var result = GetExpressionContext().CompileDynamic("Sub.SayHello(\"!!!\")").Evaluate();
+            Assert.AreEqual("Hello SubWorld!!!", result);
+        }
+
+        private static ExpressionContext GetExpressionContext()
+        {
+            var expressionOwner = new TestData { Id = "World" };
+            var context = new ExpressionContext(expressionOwner);
+            context.Imports.AddType(typeof(TestDataExtensions));
+            return context;
+        }
+    }
+}

--- a/test/Flee.Test/ExpressionTests/ExtensionMethodTestData/TestData.cs
+++ b/test/Flee.Test/ExpressionTests/ExtensionMethodTestData/TestData.cs
@@ -1,10 +1,31 @@
-﻿namespace Flee.Test.ExpressionTests.ExtensionMethodTestData
+﻿namespace Flee.OtherTests.ExtensionMethodTestData
 {
+    using Microsoft.Win32.SafeHandles;
+
     internal class TestData
     {
         public string Id { get; set; }
 
-        public TestData Sub => new TestData { Id = "Sub" + this.Id };
+        public SubTestData Sub
+        {
+            get { return new SubTestData { Id = "Sub" + this.Id }; }
+        }
+
+        public string SayHello(int times)
+        {
+            string result = string.Empty;
+            for (int i = 0; i < times; i++)
+            {
+                result += "hello ";
+            }
+
+            return result + Id;
+        }
+    }
+
+    internal class SubTestData
+    {
+        public string Id { get; set; }
 
         public string SayHello(int times)
         {

--- a/test/Flee.Test/ExpressionTests/ExtensionMethodTestData/TestData.cs
+++ b/test/Flee.Test/ExpressionTests/ExtensionMethodTestData/TestData.cs
@@ -1,0 +1,20 @@
+﻿namespace Flee.Test.ExpressionTests.ExtensionMethodTestData
+{
+    internal class TestData
+    {
+        public string Id { get; set; }
+
+        public TestData Sub => new TestData { Id = "Sub" + this.Id };
+
+        public string SayHello(int times)
+        {
+            string result = string.Empty;
+            for (int i = 0; i < times; i++)
+            {
+                result += "hello ";
+            }
+
+            return result + Id;
+        }
+    }
+}

--- a/test/Flee.Test/ExpressionTests/ExtensionMethodTestData/TestDataExtensions.cs
+++ b/test/Flee.Test/ExpressionTests/ExtensionMethodTestData/TestDataExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace Flee.Test.ExpressionTests.ExtensionMethodTestData
+{
+    internal static class TestDataExtensions
+    {
+        public static string SayHello(this TestData data)
+        {
+            return "Hello " + data.Id;
+        }
+
+        public static string SayHello(this TestData data, string suffix)
+        {
+            return "Hello " + data.Id + suffix;
+        }
+
+        public static string SayHello(this TestData data, bool friendly)
+        {
+            return "Hello " + (friendly ? "dear " : string.Empty) + data.Id;
+        }
+    }
+}

--- a/test/Flee.Test/ExpressionTests/ExtensionMethodTestData/TestDataExtensions.cs
+++ b/test/Flee.Test/ExpressionTests/ExtensionMethodTestData/TestDataExtensions.cs
@@ -1,7 +1,17 @@
-﻿namespace Flee.Test.ExpressionTests.ExtensionMethodTestData
+﻿namespace Flee.OtherTests.ExtensionMethodTestData
 {
     internal static class TestDataExtensions
     {
+        public static string SayHello(this object data)
+        {
+            if (data is TestData td)
+            {
+                return "Hello " + td.Id;
+            }
+
+            return "Hello unkown!";
+        }
+
         public static string SayHello(this TestData data)
         {
             return "Hello " + data.Id;
@@ -15,6 +25,21 @@
         public static string SayHello(this TestData data, bool friendly)
         {
             return "Hello " + (friendly ? "dear " : string.Empty) + data.Id;
+        }
+
+        public static string SayHello(this SubTestData data)
+        {
+            return "Hello as well, " + data.Id;
+        }
+
+        public static string SayHello(this SubTestData data, string suffix)
+        {
+            return "Hello as well, " + data.Id + suffix;
+        }
+
+        public static string SayHello(this SubTestData data, bool friendly)
+        {
+            return "Hello as well, " + (friendly ? "dear " : string.Empty) + data.Id;
         }
     }
 }

--- a/test/Flee.Test/Flee.Test.csproj
+++ b/test/Flee.Test/Flee.Test.csproj
@@ -39,9 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flee.Net45, Version=1.0.0.0, Culture=neutral, PublicKeyToken=951a102ce2413032, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flee.1.2.1\lib\net45\Flee.Net45.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -61,6 +58,9 @@
     <Compile Include="ExpressionTests\ExpressionBuildingTest.cs" />
     <Compile Include="ExpressionTests\Benchmarks.cs" />
     <Compile Include="ExpressionTests\Core.cs" />
+    <Compile Include="ExpressionTests\ExtensionMethodTest.cs" />
+    <Compile Include="ExpressionTests\ExtensionMethodTestData\TestData.cs" />
+    <Compile Include="ExpressionTests\ExtensionMethodTestData\TestDataExtensions.cs" />
     <Compile Include="Infrastructure\Core.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -78,6 +78,12 @@
     <Content Include="TestScripts\SimpleCalcEngineTests.txt" />
     <Content Include="TestScripts\ValidCasts.txt" />
     <Content Include="TestScripts\ValidExpressions.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Flee.Net45\Flee.Net45.csproj">
+      <Project>{658c0ed4-404a-48ec-96ff-d22c3c12ac39}</Project>
+      <Name>Flee.Net45</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/Flee.Test/packages.config
+++ b/test/Flee.Test/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flee" version="1.2.1" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="1.1.11" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.1.11" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />


### PR DESCRIPTION
This adds support for extension methods to flee. 
We already use this for a long time in our project, but we are still using a fork of the VB version:
https://github.com/ThomasZitzler/flee

I would like to use that now also on .net core, so I tought switch to you version might be a good idea.
But I would need that extension support again, so I ported my VB code to C#