### PR TITLE
Multiple critical bug fixes

### DIFF
--- a/src/Flee.Net45/ExpressionElements/Base/ExpressionElement.cs
+++ b/src/Flee.Net45/ExpressionElements/Base/ExpressionElement.cs
@@ -44,11 +44,6 @@ namespace Flee.ExpressionElements.Base
             this.ThrowCompileException(CompileErrorResourceKeys.AmbiguousOverloadedOperator, CompileExceptionReason.AmbiguousMatch, leftType.Name, rightType.Name, operation);
         }
 
-        protected FleeILGenerator CreateTempFleeILGenerator(FleeILGenerator ilgCurrent)
-        {
-            DynamicMethod dm = new DynamicMethod("temp", typeof(Int32), null, this.GetType());
-            return new FleeILGenerator(dm.GetILGenerator(), ilgCurrent.Length, true);
-        }
 
         protected string Name
         {

--- a/src/Flee.Net45/ExpressionElements/Base/Literals/LiteralElement.cs
+++ b/src/Flee.Net45/ExpressionElements/Base/Literals/LiteralElement.cs
@@ -42,7 +42,7 @@ namespace Flee.ExpressionElements.Base.Literals
             }
             else if (value >= 0 & value <= UInt32.MaxValue)
             {
-                EmitLoad(Convert.ToInt32(value), ilg);
+                ilg.Emit(OpCodes.Ldc_I4, unchecked((int)Convert.ToUInt32(value)));
                 ilg.Emit(OpCodes.Conv_U8);
             }
             else

--- a/src/Flee.Net45/ExpressionElements/Conditional.cs
+++ b/src/Flee.Net45/ExpressionElements/Conditional.cs
@@ -53,6 +53,9 @@ namespace Flee.ExpressionElements
             {
                 // If this is a fake emit, then do a fake emit and return
                 this.EmitConditional(ilg, services, bm);
+                // add the long branch offsets so our length
+                // is accurate.
+                bm.ComputeBranches(ilg);
                 return;
             }
 
@@ -62,7 +65,7 @@ namespace Flee.ExpressionElements
             // Emit fake conditional to get branch target positions
             this.EmitConditional(ilgTemp, services, bm);
 
-            bm.ComputeBranches();
+            bm.ComputeBranches(ilgTemp);
 
             // Emit real conditional now that we have the branch target locations
             this.EmitConditional(ilg, services, bm);

--- a/src/Flee.Net45/ExpressionElements/Conditional.cs
+++ b/src/Flee.Net45/ExpressionElements/Conditional.cs
@@ -45,82 +45,33 @@ namespace Flee.ExpressionElements
 
         public override void Emit(FleeILGenerator ilg, IServiceProvider services)
         {
-            BranchManager bm = new BranchManager();
-            bm.GetLabel("falseLabel", ilg);
-            bm.GetLabel("endLabel", ilg);
-
-            if (ilg.IsTemp == true)
-            {
-                // If this is a fake emit, then do a fake emit and return
-                this.EmitConditional(ilg, services, bm);
-                // add the long branch offsets so our length
-                // is accurate.
-                bm.ComputeBranches(ilg);
-                return;
-            }
-
-            FleeILGenerator ilgTemp = this.CreateTempFleeILGenerator(ilg);
-            Utility.SyncFleeILGeneratorLabels(ilg, ilgTemp);
-
-            // Emit fake conditional to get branch target positions
-            this.EmitConditional(ilgTemp, services, bm);
-
-            bm.ComputeBranches(ilgTemp);
-
-            // Emit real conditional now that we have the branch target locations
-            this.EmitConditional(ilg, services, bm);
+            this.EmitConditional(ilg, services);
         }
 
-        private void EmitConditional(FleeILGenerator ilg, IServiceProvider services, BranchManager bm)
+        private void EmitConditional(FleeILGenerator ilg, IServiceProvider services)
         {
-            Label falseLabel = bm.FindLabel("falseLabel");
-            Label endLabel = bm.FindLabel("endLabel");
+            Label falseLabel = ilg.DefineLabel();
+            Label endLabel = ilg.DefineLabel();
 
             // Emit the condition
             _myCondition.Emit(ilg, services);
 
             // On false go to the false operand
-            if (ilg.IsTemp == true)
-            {
-                bm.AddBranch(ilg, falseLabel);
-                ilg.Emit(OpCodes.Brfalse_S, falseLabel);
-            }
-            else if (bm.IsLongBranch(ilg, falseLabel) == false)
-            {
-                ilg.Emit(OpCodes.Brfalse_S, falseLabel);
-            }
-            else
-            {
-                ilg.Emit(OpCodes.Brfalse, falseLabel);
-            }
+            ilg.EmitBranchFalse(falseLabel);
 
             // Emit the true operand
             _myWhenTrue.Emit(ilg, services);
             ImplicitConverter.EmitImplicitConvert(_myWhenTrue.ResultType, _myResultType, ilg);
 
             // Jump to end
-            if (ilg.IsTemp == true)
-            {
-                bm.AddBranch(ilg, endLabel);
-                ilg.Emit(OpCodes.Br_S, endLabel);
-            }
-            else if (bm.IsLongBranch(ilg, endLabel) == false)
-            {
-                ilg.Emit(OpCodes.Br_S, endLabel);
-            }
-            else
-            {
-                ilg.Emit(OpCodes.Br, endLabel);
-            }
+            ilg.EmitBranch(endLabel);
 
-            bm.MarkLabel(ilg, falseLabel);
             ilg.MarkLabel(falseLabel);
 
             // Emit the false operand
             _myWhenFalse.Emit(ilg, services);
             ImplicitConverter.EmitImplicitConvert(_myWhenFalse.ResultType, _myResultType, ilg);
             // Fall through to end
-            bm.MarkLabel(ilg, endLabel);
             ilg.MarkLabel(endLabel);
         }
 

--- a/src/Flee.Net45/ExpressionElements/In.cs
+++ b/src/Flee.Net45/ExpressionElements/In.cs
@@ -118,33 +118,11 @@ namespace Flee.ExpressionElements
             if ((MyTargetCollectionType != null))
             {
                 this.EmitCollectionIn(ilg, services);
-
             }
             else
             {
-                BranchManager bm = new BranchManager();
-                bm.GetLabel("endLabel", ilg);
-                bm.GetLabel("trueTerminal", ilg);
-
-                if (ilg.IsTemp)
-                {
-                    // no real emit needed.
-                    this.EmitListIn(ilg, services, bm);
-                    // expand IL space to fit long branches
-                    bm.ComputeBranches(ilg);
-                    return;
-                }
-
-                // Do a fake emit to get branch positions
-                FleeILGenerator ilgTemp = this.CreateTempFleeILGenerator(ilg);
-                Utility.SyncFleeILGeneratorLabels(ilg, ilgTemp);
-
-                this.EmitListIn(ilgTemp, services, bm);
-
-                bm.ComputeBranches(ilg);
-
                 // Do the real emit
-                this.EmitListIn(ilg, services, bm);
+                this.EmitListIn(ilg, services);
             }
         }
 
@@ -176,11 +154,11 @@ namespace Flee.ExpressionElements
             return MyTargetCollectionType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
         }
 
-        private void EmitListIn(FleeILGenerator ilg, IServiceProvider services, BranchManager bm)
+        private void EmitListIn(FleeILGenerator ilg, IServiceProvider services)
         {
             CompareElement ce = new CompareElement();
-            Label endLabel = bm.FindLabel("endLabel");
-            Label trueTerminal = bm.FindLabel("trueTerminal");
+            Label endLabel = ilg.DefineLabel();
+            Label trueTerminal = ilg.DefineLabel();
 
             // Cache the operand since we will be comparing against it a lot
             LocalBuilder lb = ilg.DeclareLocal(MyOperand.ResultType);
@@ -198,37 +176,22 @@ namespace Flee.ExpressionElements
                 ce.Initialize(targetShim, argumentElement, LogicalCompareOperation.Equal);
                 ce.Emit(ilg, services);
 
-                EmitBranchToTrueTerminal(ilg, trueTerminal, bm);
+                EmitBranchToTrueTerminal(ilg, trueTerminal);
             }
 
             ilg.Emit(OpCodes.Ldc_I4_0);
-            // only 1 opcode between here and endLabel, so always short
             ilg.Emit(OpCodes.Br_S, endLabel);
 
-            bm.MarkLabel(ilg, trueTerminal);
             ilg.MarkLabel(trueTerminal);
 
             ilg.Emit(OpCodes.Ldc_I4_1);
 
-            bm.MarkLabel(ilg, endLabel);
             ilg.MarkLabel(endLabel);
         }
 
-        private static void EmitBranchToTrueTerminal(FleeILGenerator ilg, Label trueTerminal, BranchManager bm)
+        private static void EmitBranchToTrueTerminal(FleeILGenerator ilg, Label trueTerminal)
         {
-            if (ilg.IsTemp == true)
-            {
-                bm.AddBranch(ilg, trueTerminal);
-                ilg.Emit(OpCodes.Brtrue_S, trueTerminal);
-            }
-            else if (bm.IsLongBranch(ilg, trueTerminal) == false)
-            {
-                ilg.Emit(OpCodes.Brtrue_S, trueTerminal);
-            }
-            else
-            {
-                ilg.Emit(OpCodes.Brtrue, trueTerminal);
-            }
+            ilg.EmitBranchTrue(trueTerminal);
         }
 
         public override System.Type ResultType => typeof(bool);

--- a/src/Flee.Net45/ExpressionElements/In.cs
+++ b/src/Flee.Net45/ExpressionElements/In.cs
@@ -126,13 +126,22 @@ namespace Flee.ExpressionElements
                 bm.GetLabel("endLabel", ilg);
                 bm.GetLabel("trueTerminal", ilg);
 
+                if (ilg.IsTemp)
+                {
+                    // no real emit needed.
+                    this.EmitListIn(ilg, services, bm);
+                    // expand IL space to fit long branches
+                    bm.ComputeBranches(ilg);
+                    return;
+                }
+
                 // Do a fake emit to get branch positions
                 FleeILGenerator ilgTemp = this.CreateTempFleeILGenerator(ilg);
                 Utility.SyncFleeILGeneratorLabels(ilg, ilgTemp);
 
                 this.EmitListIn(ilgTemp, services, bm);
 
-                bm.ComputeBranches();
+                bm.ComputeBranches(ilg);
 
                 // Do the real emit
                 this.EmitListIn(ilg, services, bm);
@@ -193,6 +202,7 @@ namespace Flee.ExpressionElements
             }
 
             ilg.Emit(OpCodes.Ldc_I4_0);
+            // only 1 opcode between here and endLabel, so always short
             ilg.Emit(OpCodes.Br_S, endLabel);
 
             bm.MarkLabel(ilg, trueTerminal);

--- a/src/Flee.Net45/InternalTypes/BranchManager.cs
+++ b/src/Flee.Net45/InternalTypes/BranchManager.cs
@@ -9,13 +9,24 @@ namespace Flee.InternalTypes
     [Obsolete("Manages branch information and allows us to determine if we should emit a short or long branch")]
     internal class BranchManager
     {
-        private IList<BranchInfo> MyBranchInfos;
+        private readonly IList<BranchInfo> MyBranchInfos;
 
-        private IDictionary<object, Label> MyKeyLabelMap;
         public BranchManager()
         {
             MyBranchInfos = new List<BranchInfo>();
-            MyKeyLabelMap = new Dictionary<object, Label>();
+        }
+
+        /// <summary>
+        /// check if any long branches exist
+        /// </summary>
+        /// <returns></returns>
+        public bool HasLongBranches()
+        {
+            foreach (BranchInfo bi in MyBranchInfos)
+            {
+                if (bi.ComputeIsLongBranch()) return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -24,19 +35,25 @@ namespace Flee.InternalTypes
         /// for the long branches needed.
         /// </summary>
         /// <remarks></remarks>
-        public void ComputeBranches(FleeILGenerator ilg)
+        public bool ComputeBranches()
         {
-            List<BranchInfo> betweenBranches = new List<BranchInfo>();
-
-            foreach (BranchInfo bi in MyBranchInfos)
+            //
+            // we need to iterate in reverse order of the
+            // starting location, as branch between our 
+            // branch could push our branch to a long branch.
+            //
+            for( var idx=MyBranchInfos.Count-1; idx >= 0; idx--)
             {
-                betweenBranches.Clear();
+                var bi = MyBranchInfos[idx];
 
-                // Find any branches between the start and end locations of this branch
-                this.FindBetweenBranches(bi, betweenBranches);
-
-                // Count the number of long branches in the above set
-                int longBranchesBetween = this.CountLongBranches(betweenBranches);
+                // count long branches between
+                int longBranchesBetween = 0;
+                for( var ii=idx+1; ii < MyBranchInfos.Count; ii++)
+                {
+                    var bi2 = MyBranchInfos[ii];
+                    if (bi2.IsBetween(bi) && bi2.ComputeIsLongBranch())
+                        ++longBranchesBetween;
+                }
 
                 // Adjust the branch as necessary
                 bi.AdjustForLongBranchesBetween(longBranchesBetween);
@@ -56,71 +73,31 @@ namespace Flee.InternalTypes
                 // Keep a tally of the number of long branches
                 longBranchCount += Convert.ToInt32(bi.IsLongBranch);
             }
-            //
-            // emit the Nop so our IL generator is the correct size.
-            while( longBranchCount-- > 0 )
-            {
-                ilg.Emit(OpCodes.Nop);
-                ilg.Emit(OpCodes.Nop);
-                ilg.Emit(OpCodes.Nop);
-            }
+
+            return  (longBranchCount > 0);
         }
 
-        /// <summary>
-        /// Count the number of long branches in a set
-        /// </summary>
-        /// <param name="dest"></param>
-        /// <returns></returns>
-        /// <remarks></remarks>
-        private int CountLongBranches(ICollection<BranchInfo> dest)
-        {
-            int count = 0;
-
-            foreach (BranchInfo bi in dest)
-            {
-                count += Convert.ToInt32(bi.ComputeIsLongBranch());
-            }
-
-            return count;
-        }
-
-        /// <summary>
-        /// Find all the branches between the start and end locations of a target branch
-        /// </summary>
-        /// <param name="target"></param>
-        /// <param name="dest"></param>
-        /// <remarks></remarks>
-        private void FindBetweenBranches(BranchInfo target, ICollection<BranchInfo> dest)
-        {
-            foreach (BranchInfo bi in MyBranchInfos)
-            {
-                if (bi.IsBetween(target) == true)
-                {
-                    dest.Add(bi);
-                }
-            }
-        }
 
         /// <summary>
         /// Determine if a branch from a point to a label will be long
         /// </summary>
         /// <param name="ilg"></param>
-        /// <param name="target"></param>
         /// <returns></returns>
         /// <remarks></remarks>
-        public bool IsLongBranch(FleeILGenerator ilg, Label target)
+        public bool IsLongBranch(FleeILGenerator ilg)
         {
-			//return true;
             ILLocation startLoc = new ILLocation(ilg.Length);
-            BranchInfo bi = new BranchInfo(startLoc, target);
 
-            int index = MyBranchInfos.IndexOf(bi);
-			if (index > -1 && index < MyBranchInfos.Count)
-			{
-				bi = MyBranchInfos[index];
-			}
+            foreach (var bi in MyBranchInfos)
+            {
+                if (bi.Equals(startLoc))
+                    return bi.IsLongBranch;
+            }
 
-            return bi.IsLongBranch;
+            // we don't really know since this branch didn't exist.
+            // we could throw an exceptio but 
+            // do a long branch to be safe.
+            return true;
         }
 
         /// <summary>
@@ -134,48 +111,10 @@ namespace Flee.InternalTypes
             ILLocation startLoc = new ILLocation(ilg.Length);
 
             BranchInfo bi = new BranchInfo(startLoc, target);
+            // branches will be sorted in order
             MyBranchInfos.Add(bi);
         }
 
-        /// <summary>
-        /// Get a label by a key
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        /// <remarks></remarks>
-        public Label FindLabel(object key)
-        {
-            return MyKeyLabelMap[key];
-        }
-
-        /// <summary>
-        /// Get a label by a key.  Create the label if it is not present.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="ilg"></param>
-        /// <returns></returns>
-        /// <remarks></remarks>
-        public Label GetLabel(object key, FleeILGenerator ilg)
-        {
-            Label lbl;
-            if (MyKeyLabelMap.TryGetValue(key, out lbl) == false)
-            {
-                lbl = ilg.DefineLabel();
-                MyKeyLabelMap.Add(key, lbl);
-            }
-            return lbl;
-        }
-
-        /// <summary>
-        /// Determines if we have a label for a key
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        /// <remarks></remarks>
-        public bool HasLabel(object key)
-        {
-            return MyKeyLabelMap.ContainsKey(key);
-        }
 
         /// <summary>
         /// Set the position for a label
@@ -278,12 +217,13 @@ namespace Flee.InternalTypes
     }
 
     [Obsolete("Represents a branch from a start location to an end location")]
-    internal class BranchInfo : IEquatable<BranchInfo>
+    internal class BranchInfo 
     {
         private readonly ILLocation _myStart;
         private readonly ILLocation _myEnd;
         private Label _myLabel;
         private bool _myIsLongBranch;
+
         public BranchInfo(ILLocation startLocation, Label endLabel)
         {
             _myStart = startLocation;
@@ -294,6 +234,9 @@ namespace Flee.InternalTypes
         public void AdjustForLongBranches(int longBranchCount)
         {
             _myStart.AdjustForLongBranch(longBranchCount);
+            // end not necessarily needed once we determine
+            // if this is long, but keep it accurate anyway.
+            _myEnd.AdjustForLongBranch(longBranchCount);
         }
 
         public void BakeIsLongBranch()
@@ -324,13 +267,16 @@ namespace Flee.InternalTypes
             }
         }
 
-        public bool Equals1(BranchInfo other)
+        /// <summary>
+        /// We only need to compare the start point. Can only have a single
+        /// brach from the exact address, so if label doesn't match we have
+        /// bigger problems.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool Equals(ILLocation start)
         {
-            return _myStart.Equals1(other._myStart) && _myLabel.Equals(other._myLabel);
-        }
-        bool System.IEquatable<BranchInfo>.Equals(BranchInfo other)
-        {
-            return Equals1(other);
+            return _myStart.Equals1(start);
         }
 
         public override string ToString()

--- a/src/Flee.Net45/InternalTypes/BranchManager.cs
+++ b/src/Flee.Net45/InternalTypes/BranchManager.cs
@@ -19,10 +19,12 @@ namespace Flee.InternalTypes
         }
 
         /// <summary>
-        /// Determine whether to use short or long branches
+        /// Determine whether to use short or long branches.
+        /// This advances the ilg offset with No-op to adjust
+        /// for the long branches needed.
         /// </summary>
         /// <remarks></remarks>
-        public void ComputeBranches()
+        public void ComputeBranches(FleeILGenerator ilg)
         {
             List<BranchInfo> betweenBranches = new List<BranchInfo>();
 
@@ -53,6 +55,14 @@ namespace Flee.InternalTypes
 
                 // Keep a tally of the number of long branches
                 longBranchCount += Convert.ToInt32(bi.IsLongBranch);
+            }
+            //
+            // emit the Nop so our IL generator is the correct size.
+            while( longBranchCount-- > 0 )
+            {
+                ilg.Emit(OpCodes.Nop);
+                ilg.Emit(OpCodes.Nop);
+                ilg.Emit(OpCodes.Nop);
             }
         }
 

--- a/src/Flee.Net45/InternalTypes/Miscellaneous.cs
+++ b/src/Flee.Net45/InternalTypes/Miscellaneous.cs
@@ -238,7 +238,7 @@ namespace Flee.InternalTypes
             // Our score is the average of the scores of each parameter.  The lower the score, the better the match.
             int sum = ComputeSum(parameters, argTypes);
 
-            return sum / argTypes.Length;
+            return (float)sum / (float)argTypes.Length;
         }
 
         private static int ComputeSum(ParameterInfo[] parameters, Type[] argTypes)

--- a/src/Flee.Net45/InternalTypes/Miscellaneous.cs
+++ b/src/Flee.Net45/InternalTypes/Miscellaneous.cs
@@ -192,13 +192,13 @@ namespace Flee.InternalTypes
             }
             else if (@params.Length == 1 && argTypes.Length == 0)//extension method without parameter support -> prefer members
             {
-               _myScore = 0.1F;
+                _myScore = 0.1F;
             }
             else if (IsParamArray == true)
             {
                 _myScore = this.ComputeScoreForParamArray(@params, argTypes);
             }
-            else if(IsExtensionMethod == true)
+            else if (IsExtensionMethod == true)
             {
                 _myScore = this.ComputeScoreExtensionMethodInternal(@params, argTypes);
             }
@@ -221,7 +221,7 @@ namespace Flee.InternalTypes
 
             for (int i = 0; i <= argTypes.Length - 1; i++)
             {
-                sum += ImplicitConverter.GetImplicitConvertScore(argTypes[i], parameters[i+1].ParameterType);
+                sum += ImplicitConverter.GetImplicitConvertScore(argTypes[i], parameters[i + 1].ParameterType);
             }
 
             return sum;
@@ -321,7 +321,7 @@ namespace Flee.InternalTypes
             if (lastParam.IsDefined(typeof(ParamArrayAttribute), false) == false)
             {
                 //Extension method support
-                if(parameters.Length == argTypes.Length + 1)
+                if (parameters.Length == argTypes.Length + 1)
                 {
                     IsExtensionMethod = true;
                     return AreValidExtensionMethodArgumentsForParameters(argTypes, parameters, previous, context);
@@ -418,7 +418,7 @@ namespace Flee.InternalTypes
             //Match if every given argument is implicitly convertible to the method's corresponding parameter
             for (int i = 0; i <= argTypes.Length - 1; i++)
             {
-                if (ImplicitConverter.EmitImplicitConvert(argTypes[i], parameters[i+1].ParameterType, null) == false)
+                if (ImplicitConverter.EmitImplicitConvert(argTypes[i], parameters[i + 1].ParameterType, null) == false)
                 {
                     return false;
                 }
@@ -463,19 +463,35 @@ namespace Flee.InternalTypes
 
         public Stack Operands;
         public Stack Operators;
+        private Dictionary<object, Label> Labels;
 
-        public BranchManager Branches;
         public ShortCircuitInfo()
         {
             this.Operands = new Stack();
             this.Operators = new Stack();
-            this.Branches = new BranchManager();
+            this.Labels = new Dictionary<object, Label>();
         }
 
         public void ClearTempState()
         {
             this.Operands.Clear();
             this.Operators.Clear();
+        }
+
+        public Label AddLabel(object key, Label lbl)
+        {
+            Labels.Add(key, lbl);
+            return lbl;
+        }
+
+        public bool HasLabel(object key)
+        {
+            return Labels.ContainsKey(key);
+        }
+
+        public Label FindLabel(object key)
+        {
+            return Labels[key];
         }
     }
 

--- a/src/Flee.Net45/InternalTypes/Utility.cs
+++ b/src/Flee.Net45/InternalTypes/Utility.cs
@@ -42,10 +42,14 @@ namespace Flee.InternalTypes
                         break;
                 }
             }
+            else if (index < 256)
+            {
+                ilg.Emit(OpCodes.Stloc_S, Convert.ToByte(index));
+            }
             else
             {
-                Debug.Assert(index < 256, "local index too large");
-                ilg.Emit(OpCodes.Stloc_S, Convert.ToByte(index));
+                Debug.Assert(index < 65535, "local index too large");
+                ilg.Emit(OpCodes.Stloc, unchecked((short)Convert.ToUInt16(index)));
             }
         }
 
@@ -71,10 +75,14 @@ namespace Flee.InternalTypes
                         break;
                 }
             }
+            else if (index < 256)
+            {
+                ilg.Emit(OpCodes.Ldloc_S, Convert.ToByte(index));
+            }
             else
             {
-                Debug.Assert(index < 256, "local index too large");
-                ilg.Emit(OpCodes.Ldloc_S, Convert.ToByte(index));
+                Debug.Assert(index < 65535, "local index too large");
+                ilg.Emit(OpCodes.Ldloc, unchecked((short)Convert.ToUInt16(index)));
             }
         }
 
@@ -179,13 +187,7 @@ namespace Flee.InternalTypes
             }
         }
 
-        public static void SyncFleeILGeneratorLabels(FleeILGenerator source, FleeILGenerator target)
-        {
-            while (source.LabelCount != target.LabelCount)
-            {
-                target.DefineLabel();
-            }
-        }
+ 
 
         public static bool IsIntegralType(Type t)
         {

--- a/src/Flee.NetStandard20/ExpressionElements/Base/ExpressionElement.cs
+++ b/src/Flee.NetStandard20/ExpressionElements/Base/ExpressionElement.cs
@@ -44,11 +44,6 @@ namespace Flee.ExpressionElements.Base
             this.ThrowCompileException(CompileErrorResourceKeys.AmbiguousOverloadedOperator, CompileExceptionReason.AmbiguousMatch, leftType.Name, rightType.Name, operation);
         }
 
-        protected FleeILGenerator CreateTempFleeILGenerator(FleeILGenerator ilgCurrent)
-        {
-            DynamicMethod dm = new DynamicMethod("temp", typeof(Int32), null, this.GetType());
-            return new FleeILGenerator(dm.GetILGenerator(), ilgCurrent.Length, true);
-        }
 
         protected string Name
         {

--- a/src/Flee.NetStandard20/ExpressionElements/Base/Literals/LiteralElement.cs
+++ b/src/Flee.NetStandard20/ExpressionElements/Base/Literals/LiteralElement.cs
@@ -42,7 +42,7 @@ namespace Flee.ExpressionElements.Base.Literals
             }
             else if (value >= 0 & value <= UInt32.MaxValue)
             {
-                EmitLoad(Convert.ToInt32(value), ilg);
+                ilg.Emit(OpCodes.Ldc_I4, unchecked((int)Convert.ToUInt32(value)));
                 ilg.Emit(OpCodes.Conv_U8);
             }
             else

--- a/src/Flee.NetStandard20/ExpressionElements/Conditional.cs
+++ b/src/Flee.NetStandard20/ExpressionElements/Conditional.cs
@@ -53,6 +53,9 @@ namespace Flee.ExpressionElements
             {
                 // If this is a fake emit, then do a fake emit and return
                 this.EmitConditional(ilg, services, bm);
+                // add the long branch offsets so our length
+                // is accurate.
+                bm.ComputeBranches(ilg);
                 return;
             }
 
@@ -62,7 +65,7 @@ namespace Flee.ExpressionElements
             // Emit fake conditional to get branch target positions
             this.EmitConditional(ilgTemp, services, bm);
 
-            bm.ComputeBranches();
+            bm.ComputeBranches(ilgTemp);
 
             // Emit real conditional now that we have the branch target locations
             this.EmitConditional(ilg, services, bm);

--- a/src/Flee.NetStandard20/ExpressionElements/Conditional.cs
+++ b/src/Flee.NetStandard20/ExpressionElements/Conditional.cs
@@ -45,82 +45,33 @@ namespace Flee.ExpressionElements
 
         public override void Emit(FleeILGenerator ilg, IServiceProvider services)
         {
-            BranchManager bm = new BranchManager();
-            bm.GetLabel("falseLabel", ilg);
-            bm.GetLabel("endLabel", ilg);
-
-            if (ilg.IsTemp == true)
-            {
-                // If this is a fake emit, then do a fake emit and return
-                this.EmitConditional(ilg, services, bm);
-                // add the long branch offsets so our length
-                // is accurate.
-                bm.ComputeBranches(ilg);
-                return;
-            }
-
-            FleeILGenerator ilgTemp = this.CreateTempFleeILGenerator(ilg);
-            Utility.SyncFleeILGeneratorLabels(ilg, ilgTemp);
-
-            // Emit fake conditional to get branch target positions
-            this.EmitConditional(ilgTemp, services, bm);
-
-            bm.ComputeBranches(ilgTemp);
-
-            // Emit real conditional now that we have the branch target locations
-            this.EmitConditional(ilg, services, bm);
+            this.EmitConditional(ilg, services);
         }
 
-        private void EmitConditional(FleeILGenerator ilg, IServiceProvider services, BranchManager bm)
+        private void EmitConditional(FleeILGenerator ilg, IServiceProvider services)
         {
-            Label falseLabel = bm.FindLabel("falseLabel");
-            Label endLabel = bm.FindLabel("endLabel");
+            Label falseLabel = ilg.DefineLabel();
+            Label endLabel = ilg.DefineLabel();
 
             // Emit the condition
             _myCondition.Emit(ilg, services);
 
             // On false go to the false operand
-            if (ilg.IsTemp == true)
-            {
-                bm.AddBranch(ilg, falseLabel);
-                ilg.Emit(OpCodes.Brfalse_S, falseLabel);
-            }
-            else if (bm.IsLongBranch(ilg, falseLabel) == false)
-            {
-                ilg.Emit(OpCodes.Brfalse_S, falseLabel);
-            }
-            else
-            {
-                ilg.Emit(OpCodes.Brfalse, falseLabel);
-            }
+            ilg.EmitBranchFalse(falseLabel);
 
             // Emit the true operand
             _myWhenTrue.Emit(ilg, services);
             ImplicitConverter.EmitImplicitConvert(_myWhenTrue.ResultType, _myResultType, ilg);
 
             // Jump to end
-            if (ilg.IsTemp == true)
-            {
-                bm.AddBranch(ilg, endLabel);
-                ilg.Emit(OpCodes.Br_S, endLabel);
-            }
-            else if (bm.IsLongBranch(ilg, endLabel) == false)
-            {
-                ilg.Emit(OpCodes.Br_S, endLabel);
-            }
-            else
-            {
-                ilg.Emit(OpCodes.Br, endLabel);
-            }
+            ilg.EmitBranch(endLabel);
 
-            bm.MarkLabel(ilg, falseLabel);
             ilg.MarkLabel(falseLabel);
 
             // Emit the false operand
             _myWhenFalse.Emit(ilg, services);
             ImplicitConverter.EmitImplicitConvert(_myWhenFalse.ResultType, _myResultType, ilg);
             // Fall through to end
-            bm.MarkLabel(ilg, endLabel);
             ilg.MarkLabel(endLabel);
         }
 

--- a/src/Flee.NetStandard20/ExpressionElements/In.cs
+++ b/src/Flee.NetStandard20/ExpressionElements/In.cs
@@ -118,7 +118,6 @@ namespace Flee.ExpressionElements
             if ((MyTargetCollectionType != null))
             {
                 this.EmitCollectionIn(ilg, services);
-
             }
             else
             {
@@ -126,13 +125,22 @@ namespace Flee.ExpressionElements
                 bm.GetLabel("endLabel", ilg);
                 bm.GetLabel("trueTerminal", ilg);
 
+                if (ilg.IsTemp)
+                {
+                    // no real emit needed.
+                    this.EmitListIn(ilg, services, bm);
+                    // expand IL space to fit long branches
+                    bm.ComputeBranches(ilg);
+                    return;
+                }
+
                 // Do a fake emit to get branch positions
                 FleeILGenerator ilgTemp = this.CreateTempFleeILGenerator(ilg);
                 Utility.SyncFleeILGeneratorLabels(ilg, ilgTemp);
 
                 this.EmitListIn(ilgTemp, services, bm);
 
-                bm.ComputeBranches();
+                bm.ComputeBranches(ilgTemp);
 
                 // Do the real emit
                 this.EmitListIn(ilg, services, bm);

--- a/src/Flee.NetStandard20/InternalTypes/BranchManager.cs
+++ b/src/Flee.NetStandard20/InternalTypes/BranchManager.cs
@@ -19,10 +19,12 @@ namespace Flee.InternalTypes
         }
 
         /// <summary>
-        /// Determine whether to use short or long branches
+        /// Determine whether to use short or long branches.
+        /// This advances the ilg offset with No-op to adjust
+        /// for the long branches needed.
         /// </summary>
         /// <remarks></remarks>
-        public void ComputeBranches()
+        public void ComputeBranches(FleeILGenerator ilg)
         {
             List<BranchInfo> betweenBranches = new List<BranchInfo>();
 
@@ -53,6 +55,14 @@ namespace Flee.InternalTypes
 
                 // Keep a tally of the number of long branches
                 longBranchCount += Convert.ToInt32(bi.IsLongBranch);
+            }
+            //
+            // emit the Nop so our IL generator is the correct size.
+            while (longBranchCount-- > 0)
+            {
+                ilg.Emit(OpCodes.Nop);
+                ilg.Emit(OpCodes.Nop);
+                ilg.Emit(OpCodes.Nop);
             }
         }
 

--- a/src/Flee.NetStandard20/InternalTypes/BranchManager.cs
+++ b/src/Flee.NetStandard20/InternalTypes/BranchManager.cs
@@ -9,13 +9,24 @@ namespace Flee.InternalTypes
     [Obsolete("Manages branch information and allows us to determine if we should emit a short or long branch")]
     internal class BranchManager
     {
-        private IList<BranchInfo> MyBranchInfos;
+        private readonly IList<BranchInfo> MyBranchInfos;
 
-        private IDictionary<object, Label> MyKeyLabelMap;
         public BranchManager()
         {
             MyBranchInfos = new List<BranchInfo>();
-            MyKeyLabelMap = new Dictionary<object, Label>();
+        }
+
+        /// <summary>
+        /// check if any long branches exist
+        /// </summary>
+        /// <returns></returns>
+        public bool HasLongBranches()
+        {
+            foreach (BranchInfo bi in MyBranchInfos)
+            {
+                if (bi.ComputeIsLongBranch()) return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -24,19 +35,25 @@ namespace Flee.InternalTypes
         /// for the long branches needed.
         /// </summary>
         /// <remarks></remarks>
-        public void ComputeBranches(FleeILGenerator ilg)
+        public bool ComputeBranches()
         {
-            List<BranchInfo> betweenBranches = new List<BranchInfo>();
-
-            foreach (BranchInfo bi in MyBranchInfos)
+            //
+            // we need to iterate in reverse order of the
+            // starting location, as branch between our 
+            // branch could push our branch to a long branch.
+            //
+            for( var idx=MyBranchInfos.Count-1; idx >= 0; idx--)
             {
-                betweenBranches.Clear();
+                var bi = MyBranchInfos[idx];
 
-                // Find any branches between the start and end locations of this branch
-                this.FindBetweenBranches(bi, betweenBranches);
-
-                // Count the number of long branches in the above set
-                int longBranchesBetween = this.CountLongBranches(betweenBranches);
+                // count long branches between
+                int longBranchesBetween = 0;
+                for( var ii=idx+1; ii < MyBranchInfos.Count; ii++)
+                {
+                    var bi2 = MyBranchInfos[ii];
+                    if (bi2.IsBetween(bi) && bi2.ComputeIsLongBranch())
+                        ++longBranchesBetween;
+                }
 
                 // Adjust the branch as necessary
                 bi.AdjustForLongBranchesBetween(longBranchesBetween);
@@ -56,70 +73,31 @@ namespace Flee.InternalTypes
                 // Keep a tally of the number of long branches
                 longBranchCount += Convert.ToInt32(bi.IsLongBranch);
             }
-            //
-            // emit the Nop so our IL generator is the correct size.
-            while (longBranchCount-- > 0)
-            {
-                ilg.Emit(OpCodes.Nop);
-                ilg.Emit(OpCodes.Nop);
-                ilg.Emit(OpCodes.Nop);
-            }
+
+            return  (longBranchCount > 0);
         }
 
-        /// <summary>
-        /// Count the number of long branches in a set
-        /// </summary>
-        /// <param name="dest"></param>
-        /// <returns></returns>
-        /// <remarks></remarks>
-        private int CountLongBranches(ICollection<BranchInfo> dest)
-        {
-            int count = 0;
-
-            foreach (BranchInfo bi in dest)
-            {
-                count += Convert.ToInt32(bi.ComputeIsLongBranch());
-            }
-
-            return count;
-        }
-
-        /// <summary>
-        /// Find all the branches between the start and end locations of a target branch
-        /// </summary>
-        /// <param name="target"></param>
-        /// <param name="dest"></param>
-        /// <remarks></remarks>
-        private void FindBetweenBranches(BranchInfo target, ICollection<BranchInfo> dest)
-        {
-            foreach (BranchInfo bi in MyBranchInfos)
-            {
-                if (bi.IsBetween(target) == true)
-                {
-                    dest.Add(bi);
-                }
-            }
-        }
 
         /// <summary>
         /// Determine if a branch from a point to a label will be long
         /// </summary>
         /// <param name="ilg"></param>
-        /// <param name="target"></param>
         /// <returns></returns>
         /// <remarks></remarks>
-        public bool IsLongBranch(FleeILGenerator ilg, Label target)
+        public bool IsLongBranch(FleeILGenerator ilg)
         {
             ILLocation startLoc = new ILLocation(ilg.Length);
-            BranchInfo bi = new BranchInfo(startLoc, target);
 
-            int index = MyBranchInfos.IndexOf(bi);
-            if (index > -1 && index < MyBranchInfos.Count)
+            foreach (var bi in MyBranchInfos)
             {
-                bi = MyBranchInfos[index];
+                if (bi.Equals(startLoc))
+                    return bi.IsLongBranch;
             }
 
-            return bi.IsLongBranch;
+            // we don't really know since this branch didn't exist.
+            // we could throw an exceptio but 
+            // do a long branch to be safe.
+            return true;
         }
 
         /// <summary>
@@ -133,48 +111,10 @@ namespace Flee.InternalTypes
             ILLocation startLoc = new ILLocation(ilg.Length);
 
             BranchInfo bi = new BranchInfo(startLoc, target);
+            // branches will be sorted in order
             MyBranchInfos.Add(bi);
         }
 
-        /// <summary>
-        /// Get a label by a key
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        /// <remarks></remarks>
-        public Label FindLabel(object key)
-        {
-            return MyKeyLabelMap[key];
-        }
-
-        /// <summary>
-        /// Get a label by a key.  Create the label if it is not present.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="ilg"></param>
-        /// <returns></returns>
-        /// <remarks></remarks>
-        public Label GetLabel(object key, FleeILGenerator ilg)
-        {
-            Label lbl;
-            if (MyKeyLabelMap.TryGetValue(key, out lbl) == false)
-            {
-                lbl = ilg.DefineLabel();
-                MyKeyLabelMap.Add(key, lbl);
-            }
-            return lbl;
-        }
-
-        /// <summary>
-        /// Determines if we have a label for a key
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        /// <remarks></remarks>
-        public bool HasLabel(object key)
-        {
-            return MyKeyLabelMap.ContainsKey(key);
-        }
 
         /// <summary>
         /// Set the position for a label
@@ -277,12 +217,13 @@ namespace Flee.InternalTypes
     }
 
     [Obsolete("Represents a branch from a start location to an end location")]
-    internal class BranchInfo : IEquatable<BranchInfo>
+    internal class BranchInfo 
     {
         private readonly ILLocation _myStart;
         private readonly ILLocation _myEnd;
         private Label _myLabel;
         private bool _myIsLongBranch;
+
         public BranchInfo(ILLocation startLocation, Label endLabel)
         {
             _myStart = startLocation;
@@ -293,6 +234,9 @@ namespace Flee.InternalTypes
         public void AdjustForLongBranches(int longBranchCount)
         {
             _myStart.AdjustForLongBranch(longBranchCount);
+            // end not necessarily needed once we determine
+            // if this is long, but keep it accurate anyway.
+            _myEnd.AdjustForLongBranch(longBranchCount);
         }
 
         public void BakeIsLongBranch()
@@ -323,13 +267,16 @@ namespace Flee.InternalTypes
             }
         }
 
-        public bool Equals1(BranchInfo other)
+        /// <summary>
+        /// We only need to compare the start point. Can only have a single
+        /// brach from the exact address, so if label doesn't match we have
+        /// bigger problems.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool Equals(ILLocation start)
         {
-            return _myStart.Equals1(other._myStart) && _myLabel.Equals(other._myLabel);
-        }
-        bool System.IEquatable<BranchInfo>.Equals(BranchInfo other)
-        {
-            return Equals1(other);
+            return _myStart.Equals1(start);
         }
 
         public override string ToString()

--- a/src/Flee.NetStandard20/InternalTypes/Expression.cs
+++ b/src/Flee.NetStandard20/InternalTypes/Expression.cs
@@ -87,13 +87,20 @@ namespace Flee.InternalTypes
 
             // Emit the IL
             rootElement.Emit(ilg, services);
+            if (ilg.NeedsSecondPass())
+            {
+                // second pass required due to long branches.
+                dm = this.CreateDynamicMethod();
+                ilg.PrepareSecondPass(dm.GetILGenerator());
+                rootElement.Emit(ilg, services);
+            }
 
             ilg.ValidateLength();
 
             // Emit to an assembly if required
             if (options.EmitToAssembly == true)
             {
-                EmitToAssembly(rootElement, services);
+                EmitToAssembly(ilg, rootElement, services);
             }
 
             Type delegateType = typeof(ExpressionEvaluator<>).MakeGenericType(typeof(T));
@@ -124,7 +131,14 @@ namespace Flee.InternalTypes
             dest.AddService(typeof(ExpressionInfo), _myInfo);
         }
 
-        private static void EmitToAssembly(ExpressionElement rootElement, IServiceContainer services)
+        /// <summary>
+        /// Emit to an assembly. We've already computed long branches at this point,
+        /// so we emit as a second pass
+        /// </summary>
+        /// <param name="ilg"></param>
+        /// <param name="rootElement"></param>
+        /// <param name="services"></param>
+        private static void EmitToAssembly(FleeILGenerator ilg, ExpressionElement rootElement, IServiceContainer services)
         {
             AssemblyName assemblyName = new AssemblyName(EmitAssemblyName);
 
@@ -135,7 +149,8 @@ namespace Flee.InternalTypes
 
             MethodBuilder mb = moduleBuilder.DefineGlobalMethod("Evaluate", MethodAttributes.Public | MethodAttributes.Static, typeof(T), new Type[] {
             typeof(object),typeof(ExpressionContext),typeof(VariableCollection)});
-            FleeILGenerator ilg = new FleeILGenerator(mb.GetILGenerator());
+            // already emitted once for local use,
+            ilg.PrepareSecondPass(mb.GetILGenerator());
 
             rootElement.Emit(ilg, services);
 

--- a/src/Flee.NetStandard20/InternalTypes/Miscellaneous.cs
+++ b/src/Flee.NetStandard20/InternalTypes/Miscellaneous.cs
@@ -238,7 +238,7 @@ namespace Flee.InternalTypes
             // Our score is the average of the scores of each parameter.  The lower the score, the better the match.
             int sum = ComputeSum(parameters, argTypes);
 
-            return sum / argTypes.Length;
+            return (float)sum / (float)argTypes.Length;
         }
 
         private static int ComputeSum(ParameterInfo[] parameters, Type[] argTypes)

--- a/src/Flee.NetStandard20/InternalTypes/Miscellaneous.cs
+++ b/src/Flee.NetStandard20/InternalTypes/Miscellaneous.cs
@@ -463,19 +463,35 @@ namespace Flee.InternalTypes
 
         public Stack Operands;
         public Stack Operators;
+        private Dictionary<object, Label> Labels;
 
-        public BranchManager Branches;
         public ShortCircuitInfo()
         {
             this.Operands = new Stack();
             this.Operators = new Stack();
-            this.Branches = new BranchManager();
+            this.Labels = new Dictionary<object, Label>();
         }
 
         public void ClearTempState()
         {
             this.Operands.Clear();
             this.Operators.Clear();
+        }
+
+        public Label AddLabel(object key, Label lbl)
+        {
+            Labels.Add(key, lbl);
+            return lbl;
+        }
+
+        public bool HasLabel(object key)
+        {
+            return Labels.ContainsKey(key);
+        }
+
+        public Label FindLabel(object key)
+        {
+            return Labels[key];
         }
     }
 

--- a/src/Flee.NetStandard20/InternalTypes/Utility.cs
+++ b/src/Flee.NetStandard20/InternalTypes/Utility.cs
@@ -42,10 +42,14 @@ namespace Flee.InternalTypes
                         break;
                 }
             }
+            else if (index < 256)
+            {
+                ilg.Emit(OpCodes.Stloc_S, Convert.ToByte(index));
+            }
             else
             {
-                Debug.Assert(index < 256, "local index too large");
-                ilg.Emit(OpCodes.Stloc_S, Convert.ToByte(index));
+                Debug.Assert(index < 65535, "local index too large");
+                ilg.Emit(OpCodes.Stloc, unchecked((short)Convert.ToUInt16(index)));
             }
         }
 
@@ -71,10 +75,14 @@ namespace Flee.InternalTypes
                         break;
                 }
             }
+            else if (index < 256)
+            {
+                ilg.Emit(OpCodes.Ldloc_S, Convert.ToByte(index));
+            }
             else
             {
-                Debug.Assert(index < 256, "local index too large");
-                ilg.Emit(OpCodes.Ldloc_S, Convert.ToByte(index));
+                Debug.Assert(index < 65535, "local index too large");
+                ilg.Emit(OpCodes.Ldloc, unchecked((short)Convert.ToUInt16(index)));
             }
         }
 
@@ -179,13 +187,7 @@ namespace Flee.InternalTypes
             }
         }
 
-        public static void SyncFleeILGeneratorLabels(FleeILGenerator source, FleeILGenerator target)
-        {
-            while (source.LabelCount != target.LabelCount)
-            {
-                target.DefineLabel();
-            }
-        }
+ 
 
         public static bool IsIntegralType(Type t)
         {

--- a/src/Flee.NetStandard20/Parsing/ExpressionParser.cs
+++ b/src/Flee.NetStandard20/Parsing/ExpressionParser.cs
@@ -12,7 +12,7 @@ namespace Flee.Parsing
     /// <summary>
     /// A token stream parser.
     /// </summary>
-    internal class ExpressionParser : RecursiveDescentParser
+    internal class ExpressionParser : StackParser
     {
         private enum SynteticPatterns
         {

--- a/src/Flee.NetStandard20/Parsing/ExpressionTokenizer.cs
+++ b/src/Flee.NetStandard20/Parsing/ExpressionTokenizer.cs
@@ -121,13 +121,13 @@ namespace Flee.Parsing
 
             customPattern = new RealPattern(Convert.ToInt32(ExpressionConstants.REAL), "REAL", TokenPattern.PatternType.REGEXP, "\\d{0}\\{1}\\d+([e][+-]\\d{{1,3}})?(d|f|m)?");
             customPattern.Initialize(Convert.ToInt32(ExpressionConstants.REAL), "REAL", TokenPattern.PatternType.REGEXP, "\\d{0}\\{1}\\d+([e][+-]\\d{{1,3}})?(d|f|m)?", _myContext);
-            AddPattern(customPattern);
+            AddPattern(customPattern, false);
 
             pattern = new TokenPattern(Convert.ToInt32(ExpressionConstants.STRING_LITERAL), "STRING_LITERAL", TokenPattern.PatternType.REGEXP, "\"([^\"\\r\\n\\\\]|\\\\u[0-9a-f]{4}|\\\\[\\\\\"'trn])*\"");
-            AddPattern(pattern);
+            AddPattern(pattern, false);
 
             pattern = new TokenPattern(Convert.ToInt32(ExpressionConstants.CHAR_LITERAL), "CHAR_LITERAL", TokenPattern.PatternType.REGEXP, "'([^'\\r\\n\\\\]|\\\\u[0-9a-f]{4}|\\\\[\\\\\"'trn])'");
-            AddPattern(pattern);
+            AddPattern(pattern, false);
 
             pattern = new TokenPattern(Convert.ToInt32(ExpressionConstants.TRUE), "TRUE", TokenPattern.PatternType.STRING, "True");
             AddPattern(pattern);
@@ -145,7 +145,7 @@ namespace Flee.Parsing
             AddPattern(pattern);
 
             pattern = new TokenPattern(Convert.ToInt32(ExpressionConstants.TIMESPAN), "TIMESPAN", TokenPattern.PatternType.REGEXP, "##(\\d+\\.)?\\d{2}:\\d{2}(:\\d{2}(\\.\\d{1,7})?)?#");
-            AddPattern(pattern);
+            AddPattern(pattern, false);
 
             pattern = new TokenPattern(Convert.ToInt32(ExpressionConstants.DATETIME), "DATETIME", TokenPattern.PatternType.REGEXP, "#[^#]+#");
             AddPattern(pattern);

--- a/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/ParserCreationException.cs
+++ b/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/ParserCreationException.cs
@@ -62,7 +62,7 @@ namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
              * of production patterns (i.e. the grammar) contains
              * ambiguities that cannot be resolved.
              */
-            INHERENT_AMBIGUITY,
+            INHERENT_AMBIGUITY
 
 
 

--- a/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/ParserCreationException.cs
+++ b/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/ParserCreationException.cs
@@ -62,7 +62,10 @@ namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
              * of production patterns (i.e. the grammar) contains
              * ambiguities that cannot be resolved.
              */
-            INHERENT_AMBIGUITY
+            INHERENT_AMBIGUITY,
+
+
+
         }
 
         private readonly ErrorType _type;

--- a/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/StackParser.cs
+++ b/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/StackParser.cs
@@ -1,0 +1,764 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
+{
+    /**
+     * based on recursive descent parser, this implementation removes recursion
+     * and uses a stack instead. This parser handles LL(n) grammars,
+     * selecting the appropriate pattern to parse based on the next few
+     * tokens. 
+     */
+    internal class StackParser : Parser
+    {
+        /**
+         * this is the parser state that is pushed onto the stack, simulating
+         * the variable state needed in recursive version. Some variables
+         * substitute for execution position, such as validnext, so patterns
+         * are processed in the proper order.
+         */
+        internal class ParseState
+        {
+            /**
+             * pattern for this state
+             */
+            internal ProductionPattern pattern;
+            /**
+             * index of the alt pattern we are currently checking
+             */
+            internal int altindex;
+
+            /**
+             * index into the list of elements for the alt pattern
+             */
+            internal int elementindex;
+
+            /**
+             * index to the token we are processing.
+             */
+            internal int tokenindex;
+
+            /**
+             * The node for current state
+             */
+            internal Node node;
+
+            /**
+             * true if we already checked IsNext on the current pattern
+             * so we should not call it again
+             */
+            internal bool validnext;
+
+        }
+
+
+        public StackParser(TextReader input) : base(input)
+        {
+        }
+
+        public StackParser(TextReader input, Analyzer analyzer)
+            : base(input, analyzer)
+        {
+        }
+
+        public StackParser(Tokenizer tokenizer)
+            : base(tokenizer)
+        {
+        }
+
+        public StackParser(Tokenizer tokenizer,
+                                      Analyzer analyzer)
+            : base(tokenizer, analyzer)
+        {
+        }
+
+        public override void AddPattern(ProductionPattern pattern)
+        {
+
+            // Check for empty matches
+            if (pattern.IsMatchingEmpty())
+            {
+                throw new ParserCreationException(
+                    ParserCreationException.ErrorType.INVALID_PRODUCTION,
+                    pattern.Name,
+                    "zero elements can be matched (minimum is one)");
+            }
+
+            // Check for left-recusive patterns
+            if (pattern.IsLeftRecursive())
+            {
+                throw new ParserCreationException(
+                    ParserCreationException.ErrorType.INVALID_PRODUCTION,
+                    pattern.Name,
+                    "left recursive patterns are not allowed");
+            }
+
+            // Add pattern
+            base.AddPattern(pattern);
+        }
+
+        public override void Prepare()
+        {
+            // Performs production pattern checks
+            base.Prepare();
+            SetInitialized(false);
+
+            // Calculate production look-ahead sets
+            var e = GetPatterns().GetEnumerator();
+            while (e.MoveNext())
+            {
+                CalculateLookAhead((ProductionPattern)e.Current);
+            }
+
+            // Set initialized flag
+            SetInitialized(true);
+        }
+
+        protected override Node ParseStart()
+        {
+            var node = ParsePatterns(GetStartPattern());
+
+
+            var token = PeekToken(0);
+            if (token != null)
+            {
+                var list = new ArrayList(1) { "<EOF>" };
+                throw new ParseException(
+                    ParseException.ErrorType.UNEXPECTED_TOKEN,
+                    token.ToShortString(),
+                    list,
+                    token.StartLine,
+                    token.StartColumn);
+            }
+            return node;
+        }
+
+
+
+        private ParseState NewState(ProductionPattern pattern)
+        {
+            return new ParseState()
+            {
+                pattern = pattern,
+                altindex = 0,
+                elementindex = 0,
+                tokenindex = 0,
+                node = null,
+                validnext = false
+            };
+        }
+
+        /// <summary>
+        /// parse patterns using a stack. The stack is local to this method, since the parser
+        /// is a singleton and may be parsing expressions from multiple threads, so cannot
+        /// use the object to store our stack.
+        /// </summary>
+        /// <param name="start"></param>
+        /// <returns></returns>
+        private Node ParsePatterns(ProductionPattern start)
+        {
+            Stack<ParseState> _stack = new Stack<ParseState>();
+            _stack.Push(NewState(start));
+
+            while (_stack.Count > 0)
+            {
+                ParseState state = _stack.Peek();
+                ProductionPattern pattern = state.pattern;
+                var defaultAlt = pattern.DefaultAlternative;
+                ProductionPattern nextpattern = null;
+                while (state.altindex < pattern.Count)
+                {
+                    var alt = pattern[state.altindex];
+                    if (state.validnext || (defaultAlt != alt && IsNext(alt)))
+                    {
+                        state.validnext = true;
+                        nextpattern = ParseAlternative(state, alt);
+                        break;
+                    }
+                    else
+                    {
+                        state.altindex++;
+                        state.validnext = false;
+                    }
+                }
+
+                // check if completed pass through alt patterns. try default
+                if (state.altindex >= pattern.Count)
+                {
+                    if (!state.validnext && (defaultAlt == null || !IsNext(defaultAlt)))
+                    {
+                        ThrowParseException(FindUnion(pattern));
+                    }
+                    else
+                    {
+                        state.validnext = true;
+                        nextpattern = ParseAlternative(state, defaultAlt);
+                    }
+                }
+                
+                if (nextpattern != null)
+                {
+                    _stack.Push(NewState(nextpattern));
+                }
+
+                // we finished current pattern, so back up to previous state.
+                else
+                {
+                    // if we have a node set, add it to the parent 
+                    var child = state.node;
+                    _stack.Pop();
+                    if (_stack.Count == 0)
+                    {
+                        // back to top, can return our result, which is top node
+                        return child;
+                    }
+                    state = _stack.Peek();
+                    AddNode((Production)state.node, child);
+                }
+            }
+
+            // should never get here, but must show we return something.
+            return null;
+        }
+
+        /**
+         * return the pattern to push onto stack and process next.
+         */
+        private ProductionPattern ParseAlternative(ParseState state, ProductionPatternAlternative alt)
+        {
+            if (state.node == null)
+            {
+                state.node = NewProduction(alt.Pattern);
+                state.elementindex = 0;
+                EnterNode(state.node);
+            }
+            while (state.elementindex < alt.Count)
+            {
+                try
+                {
+                    var pattern = ParseElement(state, alt[state.elementindex]);
+                    if (pattern == null)
+                        state.elementindex++;
+                    else
+                        return pattern;
+                }
+                catch (ParseException e)
+                {
+                    AddError(e, true);
+                    NextToken();
+                }
+            }
+
+            state.node = ExitNode(state.node);
+            return null;
+        }
+
+        private ProductionPattern ParseElement(ParseState state,
+                                  ProductionPatternElement elem)
+        {
+            for (int i = state.tokenindex; i < elem.MaxCount; i++)
+            {
+                if (i < elem.MinCount || IsNext(elem))
+                {
+                    Node child;
+                    if (elem.IsToken())
+                    {
+                        child = NextToken(elem.Id);
+                        EnterNode(child);
+                        AddNode((Production)state.node, ExitNode(child));
+                    }
+                    else
+                    {
+                        // continue from next token when we return
+                        state.tokenindex = i + 1;
+                        // return to start processing the new pattern at this state
+                        return GetPattern(elem.Id); ;
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+            //
+            // we completed processing this element
+            state.tokenindex = 0;
+            return null;
+        }
+
+        private bool IsNext(ProductionPattern pattern)
+        {
+            LookAheadSet set = pattern.LookAhead;
+
+            if (set == null)
+            {
+                return false;
+            }
+            else
+            {
+                return set.IsNext(this);
+            }
+        }
+
+        private bool IsNext(ProductionPatternAlternative alt)
+        {
+            LookAheadSet set = alt.LookAhead;
+
+            if (set == null)
+            {
+                return false;
+            }
+            else
+            {
+                return set.IsNext(this);
+            }
+        }
+
+        private bool IsNext(ProductionPatternElement elem)
+        {
+            LookAheadSet set = elem.LookAhead;
+
+            if (set != null)
+            {
+                return set.IsNext(this);
+            }
+            else if (elem.IsToken())
+            {
+                return elem.IsMatch(PeekToken(0));
+            }
+            else
+            {
+                return IsNext(GetPattern(elem.Id));
+            }
+        }
+
+        private void CalculateLookAhead(ProductionPattern pattern)
+        {
+            ProductionPatternAlternative alt;
+            LookAheadSet previous = new LookAheadSet(0);
+            int length = 1;
+            int i;
+            CallStack stack = new CallStack();
+
+            // Calculate simple look-ahead
+            stack.Push(pattern.Name, 1);
+            var result = new LookAheadSet(1);
+            var alternatives = new LookAheadSet[pattern.Count];
+            for (i = 0; i < pattern.Count; i++)
+            {
+                alt = pattern[i];
+                alternatives[i] = FindLookAhead(alt, 1, 0, stack, null);
+                alt.LookAhead = alternatives[i];
+                result.AddAll(alternatives[i]);
+            }
+            if (pattern.LookAhead == null)
+            {
+                pattern.LookAhead = result;
+            }
+            var conflicts = FindConflicts(pattern, 1);
+
+            // Resolve conflicts
+            while (conflicts.Size() > 0)
+            {
+                length++;
+                stack.Clear();
+                stack.Push(pattern.Name, length);
+                conflicts.AddAll(previous);
+                for (i = 0; i < pattern.Count; i++)
+                {
+                    alt = pattern[i];
+                    if (alternatives[i].Intersects(conflicts))
+                    {
+                        alternatives[i] = FindLookAhead(alt,
+                                                        length,
+                                                        0,
+                                                        stack,
+                                                        conflicts);
+                        alt.LookAhead = alternatives[i];
+                    }
+                    if (alternatives[i].Intersects(conflicts))
+                    {
+                        if (pattern.DefaultAlternative == null)
+                        {
+                            pattern.DefaultAlternative = alt;
+                        }
+                        else if (pattern.DefaultAlternative != alt)
+                        {
+                            result = alternatives[i].CreateIntersection(conflicts);
+                            ThrowAmbiguityException(pattern.Name,
+                                                    null,
+                                                    result);
+                        }
+                    }
+                }
+                previous = conflicts;
+                conflicts = FindConflicts(pattern, length);
+            }
+
+            // Resolve conflicts inside rules
+            for (i = 0; i < pattern.Count; i++)
+            {
+                CalculateLookAhead(pattern[i], 0);
+            }
+        }
+
+        private void CalculateLookAhead(ProductionPatternAlternative alt,
+                                        int pos)
+        {
+            LookAheadSet previous = new LookAheadSet(0);
+            int length = 1;
+
+            // Check trivial cases
+            if (pos >= alt.Count)
+            {
+                return;
+            }
+
+            // Check for non-optional element
+            var pattern = alt.Pattern;
+            var elem = alt[pos];
+            if (elem.MinCount == elem.MaxCount)
+            {
+                CalculateLookAhead(alt, pos + 1);
+                return;
+            }
+
+            // Calculate simple look-aheads
+            var first = FindLookAhead(elem, 1, new CallStack(), null);
+            var follow = FindLookAhead(alt, 1, pos + 1, new CallStack(), null);
+
+            // Resolve conflicts
+            var location = "at position " + (pos + 1);
+            var conflicts = FindConflicts(pattern.Name,
+                location,
+                first,
+                follow);
+            while (conflicts.Size() > 0)
+            {
+                length++;
+                conflicts.AddAll(previous);
+                first = FindLookAhead(elem,
+                                      length,
+                                      new CallStack(),
+                                      conflicts);
+                follow = FindLookAhead(alt,
+                                       length,
+                                       pos + 1,
+                                       new CallStack(),
+                                       conflicts);
+                first = first.CreateCombination(follow);
+                elem.LookAhead = first;
+                if (first.Intersects(conflicts))
+                {
+                    first = first.CreateIntersection(conflicts);
+                    ThrowAmbiguityException(pattern.Name, location, first);
+                }
+                previous = conflicts;
+                conflicts = FindConflicts(pattern.Name,
+                                          location,
+                                          first,
+                                          follow);
+            }
+
+            // Check remaining elements
+            CalculateLookAhead(alt, pos + 1);
+        }
+
+        private LookAheadSet FindLookAhead(ProductionPattern pattern,
+                                           int length,
+                                           CallStack stack,
+                                           LookAheadSet filter)
+        {
+            // Check for infinite loop
+            if (stack.Contains(pattern.Name, length))
+            {
+                throw new ParserCreationException(
+                    ParserCreationException.ErrorType.INFINITE_LOOP,
+                    pattern.Name,
+                    (String)null);
+            }
+
+            // Find pattern look-ahead
+            stack.Push(pattern.Name, length);
+            var result = new LookAheadSet(length);
+            for (int i = 0; i < pattern.Count; i++)
+            {
+                var temp = FindLookAhead(pattern[i],
+                    length,
+                    0,
+                    stack,
+                    filter);
+                result.AddAll(temp);
+            }
+            stack.Pop();
+
+            return result;
+        }
+
+        private LookAheadSet FindLookAhead(ProductionPatternAlternative alt,
+                                           int length,
+                                           int pos,
+                                           CallStack stack,
+                                           LookAheadSet filter)
+        {
+            LookAheadSet follow;
+            // Check trivial cases
+            if (length <= 0 || pos >= alt.Count)
+            {
+                return new LookAheadSet(0);
+            }
+
+            // Find look-ahead for this element
+            var first = FindLookAhead(alt[pos], length, stack, filter);
+            if (alt[pos].MinCount == 0)
+            {
+                first.AddEmpty();
+            }
+
+            // Find remaining look-ahead
+            if (filter == null)
+            {
+                length -= first.GetMinLength();
+                if (length > 0)
+                {
+                    follow = FindLookAhead(alt, length, pos + 1, stack, null);
+                    first = first.CreateCombination(follow);
+                }
+            }
+            else if (filter.IsOverlap(first))
+            {
+                var overlaps = first.CreateOverlaps(filter);
+                length -= overlaps.GetMinLength();
+                filter = filter.CreateFilter(overlaps);
+                follow = FindLookAhead(alt, length, pos + 1, stack, filter);
+                first.RemoveAll(overlaps);
+                first.AddAll(overlaps.CreateCombination(follow));
+            }
+
+            return first;
+        }
+
+        private LookAheadSet FindLookAhead(ProductionPatternElement elem,
+                                           int length,
+                                           CallStack stack,
+                                           LookAheadSet filter)
+        {
+            // Find initial element look-ahead
+            var first = FindLookAhead(elem, length, 0, stack, filter);
+            var result = new LookAheadSet(length);
+            result.AddAll(first);
+            if (filter == null || !filter.IsOverlap(result))
+            {
+                return result;
+            }
+
+            // Handle element repetitions
+            if (elem.MaxCount == Int32.MaxValue)
+            {
+                first = first.CreateRepetitive();
+            }
+            var max = elem.MaxCount;
+            if (length < max)
+            {
+                max = length;
+            }
+            for (int i = 1; i < max; i++)
+            {
+                first = first.CreateOverlaps(filter);
+                if (first.Size() <= 0 || first.GetMinLength() >= length)
+                {
+                    break;
+                }
+                var follow = FindLookAhead(elem,
+                    length,
+                    0,
+                    stack,
+                    filter.CreateFilter(first));
+                first = first.CreateCombination(follow);
+                result.AddAll(first);
+            }
+
+            return result;
+        }
+
+        private LookAheadSet FindLookAhead(ProductionPatternElement elem,
+                                           int length,
+                                           int dummy,
+                                           CallStack stack,
+                                           LookAheadSet filter)
+        {
+            LookAheadSet result;
+
+            if (elem.IsToken())
+            {
+                result = new LookAheadSet(length);
+                result.Add(elem.Id);
+            }
+            else
+            {
+                var pattern = GetPattern(elem.Id);
+                result = FindLookAhead(pattern, length, stack, filter);
+                if (stack.Contains(pattern.Name))
+                {
+                    result = result.CreateRepetitive();
+                }
+            }
+
+            return result;
+        }
+
+        private LookAheadSet FindConflicts(ProductionPattern pattern,
+                                           int maxLength)
+        {
+
+            LookAheadSet result = new LookAheadSet(maxLength);
+            for (int i = 0; i < pattern.Count; i++)
+            {
+                var set1 = pattern[i].LookAhead;
+                for (int j = 0; j < i; j++)
+                {
+                    var set2 = pattern[j].LookAhead;
+                    result.AddAll(set1.CreateIntersection(set2));
+                }
+            }
+            if (result.IsRepetitive())
+            {
+                ThrowAmbiguityException(pattern.Name, null, result);
+            }
+            return result;
+        }
+
+        private LookAheadSet FindConflicts(string pattern,
+                                           string location,
+                                           LookAheadSet set1,
+                                           LookAheadSet set2)
+        {
+            var result = set1.CreateIntersection(set2);
+            if (result.IsRepetitive())
+            {
+                ThrowAmbiguityException(pattern, location, result);
+            }
+            return result;
+        }
+
+        private LookAheadSet FindUnion(ProductionPattern pattern)
+        {
+            LookAheadSet result;
+            int length = 0;
+            int i;
+
+            for (i = 0; i < pattern.Count; i++)
+            {
+                result = pattern[i].LookAhead;
+                if (result.GetMaxLength() > length)
+                {
+                    length = result.GetMaxLength();
+                }
+            }
+            result = new LookAheadSet(length);
+            for (i = 0; i < pattern.Count; i++)
+            {
+                result.AddAll(pattern[i].LookAhead);
+            }
+
+            return result;
+        }
+
+
+        private void ThrowParseException(LookAheadSet set)
+        {
+            ArrayList list = new ArrayList();
+
+            // Read tokens until mismatch
+            while (set.IsNext(this, 1))
+            {
+                set = set.CreateNextSet(NextToken().Id);
+            }
+
+            // Find next token descriptions
+            var initials = set.GetInitialTokens();
+            for (int i = 0; i < initials.Length; i++)
+            {
+                list.Add(GetTokenDescription(initials[i]));
+            }
+
+            // Create exception
+            var token = NextToken();
+            throw new ParseException(ParseException.ErrorType.UNEXPECTED_TOKEN,
+                                     token.ToShortString(),
+                                     list,
+                                     token.StartLine,
+                                     token.StartColumn);
+        }
+
+        private void ThrowAmbiguityException(string pattern,
+                                             string location,
+                                             LookAheadSet set)
+        {
+
+            ArrayList list = new ArrayList();
+
+            // Find next token descriptions
+            var initials = set.GetInitialTokens();
+            for (int i = 0; i < initials.Length; i++)
+            {
+                list.Add(GetTokenDescription(initials[i]));
+            }
+
+            // Create exception
+            throw new ParserCreationException(
+                ParserCreationException.ErrorType.INHERENT_AMBIGUITY,
+                pattern,
+                location,
+                list);
+        }
+
+
+        private class CallStack
+        {
+            private readonly ArrayList _nameStack = new ArrayList();
+            private readonly ArrayList _valueStack = new ArrayList();
+            public bool Contains(string name)
+            {
+                return _nameStack.Contains(name);
+            }
+
+            public bool Contains(string name, int value)
+            {
+                for (int i = 0; i < _nameStack.Count; i++)
+                {
+                    if (_nameStack[i].Equals(name)
+                     && _valueStack[i].Equals(value))
+                    {
+
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            public void Clear()
+            {
+                _nameStack.Clear();
+                _valueStack.Clear();
+            }
+
+            public void Push(string name, int value)
+            {
+                _nameStack.Add(name);
+                _valueStack.Add(value);
+            }
+
+            public void Pop()
+            {
+                if (_nameStack.Count > 0)
+                {
+                    _nameStack.RemoveAt(_nameStack.Count - 1);
+                    _valueStack.RemoveAt(_valueStack.Count - 1);
+                }
+            }
+        }
+    }
+}

--- a/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/Tokenizer.cs
+++ b/src/Flee.NetStandard20/Parsing/grammatica-1.5.alpha2/PerCederberg.Grammatica.Runtime/Tokenizer.cs
@@ -86,7 +86,10 @@ namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
             return _buffer.ColumnNumber;
         }
 
-        public void AddPattern(TokenPattern pattern)
+        /**
+         * nfa - true to attempt as an nfa pattern for regexp. This handles most things except the complex repeates, ie {1,4}
+         */
+        public void AddPattern(TokenPattern pattern, bool nfa=true)
         {
             switch (pattern.Type)
             {
@@ -105,11 +108,18 @@ namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
                     }
                     break;
                 case TokenPattern.PatternType.REGEXP:
-                    try
+                    if (nfa)
                     {
-                        _nfaMatcher.AddPattern(pattern);
+                        try
+                        {
+                            _nfaMatcher.AddPattern(pattern);
+                        }
+                        catch (Exception)
+                        {
+                            nfa = false;
+                        }
                     }
-                    catch (Exception)
+                    if (!nfa)
                     {
                         try
                         {
@@ -124,6 +134,7 @@ namespace Flee.Parsing.grammatica_1._5.alpha2.PerCederberg.Grammatica.Runtime
                                 e.Message);
                         }
                     }
+
                     break;
                 default:
                     throw new ParserCreationException(

--- a/src/Flee.NetStandard20/PublicTypes/ExpressionContext.cs
+++ b/src/Flee.NetStandard20/PublicTypes/ExpressionContext.cs
@@ -96,14 +96,14 @@ namespace Flee.PublicTypes
         {
             ExpressionContext context = (ExpressionContext)this.MemberwiseClone();
             context._myProperties = _myProperties.Clone();
-            context._myProperties.SetValue("Options", this.Options.Clone());
-            context._myProperties.SetValue("ParserOptions", this.ParserOptions.Clone());
-            context._myProperties.SetValue("Imports", this.Imports.Clone());
+            context._myProperties.SetValue("Options", context.Options.Clone());
+            context._myProperties.SetValue("ParserOptions", context.ParserOptions.Clone());
+            context._myProperties.SetValue("Imports", context.Imports.Clone());
             context.Imports.SetContext(context);
 
             if (cloneVariables == true)
             {
-                context._myVariables = new VariableCollection(this);
+                context._myVariables = new VariableCollection(context);
                 this.Variables.Copy(context._myVariables);
             }
 

--- a/test/Flee.Console/Flee.Console.csproj
+++ b/test/Flee.Console/Flee.Console.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flee" Version="1.2.1" />
+    <ProjectReference Include="..\..\src\Flee.NetStandard20\Flee.NetStandard20.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Flee.Test/CalcEngineTests/LongScriptTests.cs
+++ b/test/Flee.Test/CalcEngineTests/LongScriptTests.cs
@@ -151,8 +151,16 @@ if(ceiling(First(6.29,if(6.39<100.01,6.39*0.66,6.39*.25)))-.01 = 90.99, ceiling(
 		public void CrashTest()
 		{
 			_myEngine.Context.Options.RealLiteralDataType = RealLiteralDataType.Decimal;
-			var e = _myEngine.Context.CompileDynamic(crashscript);
-			var result = e.Evaluate();
+			bool gotex = false;
+			try
+			{
+				var e = _myEngine.Context.CompileDynamic(crashscript);
+			}
+			catch (ExpressionCompileException e)
+            {
+				gotex = true;
+            }
+			Assert.IsTrue(gotex);
 		}
 
 

--- a/test/Flee.Test/CalcEngineTests/LongScriptTests.cs
+++ b/test/Flee.Test/CalcEngineTests/LongScriptTests.cs
@@ -30,7 +30,22 @@ namespace Flee.Test.CalcEngineTests
         [Test]
         public void LongScriptWithManyFunctions()
         {
-			var script = System.IO.File.ReadAllText(@"test\Flee.Test\TestScripts\LongScriptWithManyFunctions.js");
+			//var script = System.IO.File.ReadAllText(@"test\Flee.Test\TestScripts\LongScriptWithManyFunctions.js");
+			var script = @"If((""LongTextToPushScriptLengthOver256CharactersJustToMakeSureItDoesntMatter"")=""C"", 
+	(
+	If((""D"") = ""E"",
+			2,
+			3
+		)
+	),
+    (
+	If((""D"") = ""E"",
+			Ceiling((((((4000) / 46.228) + 8) * 46.228) * 3) + 5126) + 1471 / 304.8 + 20,
+			Ceiling(((((((((4000) / 46.228) + 8) * 46.228) * 3) + 5126) + 1217) / 304.8) + 20)
+		)
+	)
+)";
+			
 			var expr = _myEngine.Context.CompileDynamic(script);
 			var result = expr.Evaluate();
 
@@ -41,11 +56,67 @@ namespace Flee.Test.CalcEngineTests
 		[Test]
 		public void FailingLongScriptWithManyFunctions()
 		{
-			var script = System.IO.File.ReadAllText(@"test\Flee.Test\TestScripts\FailingLongScriptWithManyFunctions.js");
+			//var script = System.IO.File.ReadAllText(@"test\Flee.Test\TestScripts\FailingLongScriptWithManyFunctions.js");
+			var script = @"
+If(""A"" = ""A"",
+			(
+				If((""LongTextToPushScriptLengthOver256CharactersJustToMakeSureItDoesntMatter"") = ""C"",
+					(
+						If((""D"") = ""E"",
+							2,
+							3
+						)
+					),
+					(
+						If((""D"") = ""E"",
+							Ceiling((((((4000) / 46.228) + 8) * 46.228) * 3) + 5126) + 1471 / 304.8 + 20,
+							Ceiling(((((((((4000) / 46.228) + 8) * 46.228) * 3) + 5126) + 1217) / 304.8) + 20)
+						)
+					)
+				)
+	),0
+  )
+";
 			var expr = _myEngine.Context.CompileDynamic(script);
 			var result = expr.Evaluate();
 
 			Assert.AreEqual(84.0d, result);
 		}
+
+		[Test]
+		public void NestedConditionalsForLongBranches()
+		{
+			//var script = System.IO.File.ReadAllText(@"test\Flee.Test\TestScripts\NestedConditionals.js");
+			var script = @"IF(2.1 <> 2.1, 
+IF(2.1 > 2.1, 2.1, 
+IF(2.1 > 2.1 AND 2.1 <= 2.1, 2.1, 
+IF(2.1 > 2.1 AND 2.1 <= 2.1, 2.1, 2.1))), 
+IF(2.1 > 2.1, 2.1, 
+IF(2.1 > 2.1 AND 2.1 <= 2.1, 2.1, 
+IF(2.1 > 2.1 AND 2.1 <= 2.1, 2.1, 2.1))))";
+			var expr = _myEngine.Context.CompileDynamic(script);
+			var result = expr.Evaluate();
+
+			Assert.AreEqual(2.1d, Convert.ToDecimal(result));
+		}
+
+		[Test]
+		public void ShortCircuitLongBranches()
+		{
+			//var script = System.IO.File.ReadAllText(@"test\Flee.Test\TestScripts\NestedConditionals.js");
+			var script = @"IF(
+1 = 2 AND (16 * 24 + 8 * -1 < 0 OR 1+1+1+1+1+1+1+1+1+1+1+1+2+3+4+5+6+7+8+9+1+2+3+4+5+6+7+8+9+1+2+3+4+5+6+7+8+9+1+2+3*3-900 < 0)
+AND (5*6+13-6*9-3+1+2+3+4+5+6+7+8 = 5+6+7+8+9+1+2+3+4+5+6+1+2+3+4+9-48 OR 6+5+2+3+8+1*9-6*7 > 8+6*4*(15-6)*(5+1+1+1+1+1+1+1+2))
+,
+1.4d,2.6d
+)";
+			var expr = _myEngine.Context.CompileDynamic(script);
+			var result = expr.Evaluate();
+
+			Assert.AreEqual(2.6d, result);
+		}
+
+
+
 	}
 }

--- a/test/Flee.Test/ExpressionTests/Benchmarks.cs
+++ b/test/Flee.Test/ExpressionTests/Benchmarks.cs
@@ -40,9 +40,630 @@ namespace Flee.Test.ExpressionTests
             Assert.Less(sw.ElapsedMilliseconds, expectedTime, "Test time above expected value");
         }
 
+        private const String BigExpression = @"
+( 
+    NOT 
+    (
+        (VAR1 > 0 
+        OR VAR2 > 0 
+        OR VAR3 > 0) 
+        AND 
+        (
+            ( 28 In (VAR4)) 
+            OR ( 28 In (VAR5)) 
+            OR ( 28 In (VAR6)) 
+            OR ( 28 In (VAR7)) 
+            OR ( 28 In (VAR8)) 
+            OR ( 28 In (VAR9)) 
+            OR ( 28 In (VAR10)) 
+            OR ( 28 In (VAR11)) 
+            OR ( 28 In (VAR12)) 
+            OR (24 In (VAR4)) 
+            OR ( 24 In (VAR5)) 
+            OR ( 24 In (VAR6)) 
+            OR ( 24 In (VAR7)) 
+            OR ( 24 In (VAR8)) 
+            OR ( 24 In (VAR9)) 
+            OR ( 24 In (VAR10)) 
+            OR ( 24 In (VAR11)) 
+            OR ( 24 In (VAR12)) 
+            OR (25 In (VAR4)) 
+            OR ( 25 In (VAR5)) 
+            OR ( 25 In (VAR6)) 
+            OR ( 25 In (VAR7)) 
+            OR ( 25 In (VAR8)) 
+            OR ( 25 In (VAR9)) 
+            OR ( 25 In (VAR10)) 
+            OR ( 25 In (VAR11)) 
+            OR ( 25 In (VAR12))
+        ) 
+        AND 
+        (
+	        ( NOT 44 In (VAR4)) 
+            AND ( NOT 44 In (VAR5)) 
+            AND ( NOT 44 In (VAR6)) 
+            AND ( NOT 44 In (VAR7)) 
+            AND ( NOT 44 In (VAR8)) 
+            AND ( NOT 44 In (VAR9)) 
+            AND ( NOT 44 In (VAR10)) 
+            AND ( NOT 44 In (VAR11)) 
+            AND ( NOT 44 In (VAR12)) 
+            AND ( NOT 34 In (VAR4)) 
+            AND ( NOT 34 In (VAR5)) 
+            AND ( NOT 34 In (VAR6)) 
+            AND ( NOT 34 In (VAR7)) 
+            AND ( NOT 34 In (VAR8)) 
+            AND ( NOT 34 In (VAR9)) 
+            AND ( NOT 34 In (VAR10)) 
+            AND ( NOT 34 In (VAR11)) 
+            AND ( NOT 34 In (VAR12)) 
+            AND ( NOT 183 In (VAR4)) 
+            AND ( NOT 183 In (VAR5)) 
+            AND ( NOT 183 In (VAR6)) 
+            AND ( NOT 183 In (VAR7)) 
+            AND ( NOT 183 In (VAR8)) 
+            AND ( NOT 183 In (VAR9)) 
+            AND ( NOT 183 In (VAR10)) 
+            AND ( NOT 183 In (VAR11)) 
+            AND ( NOT 183 In (VAR12)) 
+            AND ( NOT 81 In (VAR4)) 
+            AND ( NOT 81 In (VAR5)) 
+            AND ( NOT 81 In (VAR6)) 
+            AND ( NOT 81 In (VAR7)) 
+            AND ( NOT 81 In (VAR8)) 
+            AND ( NOT 81 In (VAR9)) 
+            AND ( NOT 81 In (VAR10)) 
+            AND ( NOT 81 In (VAR11)) 
+            AND ( NOT 81 In (VAR12))
+        )
+    )
+) 
+AND 
+( 
+    NOT 
+    (
+        (VAR1 > 0 
+        OR VAR2 > 0 
+        OR VAR3 > 0) 
+        AND 
+        (
+            ( NOT 28 In (VAR4)) 
+            AND ( NOT 28 In (VAR5)) 
+            AND ( NOT 28 In (VAR6)) 
+            AND ( NOT 28 In (VAR7)) 
+            AND ( NOT 28 In (VAR8)) 
+            AND ( NOT 28 In (VAR9)) 
+            AND ( NOT 28 In (VAR10)) 
+            AND ( NOT 28 In (VAR11)) 
+            AND ( NOT 28 In (VAR12)) 
+            AND ( NOT 24 In (VAR4)) 
+            AND ( NOT 24 In (VAR5)) 
+            AND ( NOT 24 In (VAR6)) 
+            AND ( NOT 24 In (VAR7)) 
+            AND ( NOT 24 In (VAR8)) 
+            AND ( NOT 24 In (VAR9)) 
+            AND ( NOT 24 In (VAR10)) 
+            AND ( NOT 24 In (VAR11)) 
+            AND ( NOT 24 In (VAR12)) 
+            AND ( NOT 25 In (VAR4)) 
+            AND ( NOT 25 In (VAR5)) 
+            AND ( NOT 25 In (VAR6)) 
+            AND ( NOT 25 In (VAR7)) 
+            AND ( NOT 25 In (VAR8)) 
+            AND ( NOT 25 In (VAR9)) 
+            AND ( NOT 25 In (VAR10)) 
+            AND ( NOT 25 In (VAR11)) 
+            AND ( NOT 25 In (VAR12))
+        ) 
+        AND 
+        (
+            ( NOT 44 In (VAR4)) 
+            AND ( NOT 44 In (VAR5)) 
+            AND ( NOT 44 In (VAR6)) 
+            AND ( NOT 44 In (VAR7)) 
+            AND ( NOT 44 In (VAR8)) 
+            AND ( NOT 44 In (VAR9)) 
+            AND ( NOT 44 In (VAR10)) 
+            AND ( NOT 44 In (VAR11)) 
+            AND ( NOT 44 In (VAR12)) 
+            AND ( NOT 34 In (VAR4)) 
+            AND ( NOT 34 In (VAR5)) 
+            AND ( NOT 34 In (VAR6)) 
+            AND ( NOT 34 In (VAR7)) 
+            AND ( NOT 34 In (VAR8)) 
+            AND ( NOT 34 In (VAR9)) 
+            AND ( NOT 34 In (VAR10)) 
+            AND ( NOT 34 In (VAR11)) 
+            AND ( NOT 34 In (VAR12)) 
+            AND ( NOT 183 In (VAR4)) 
+            AND ( NOT 183 In (VAR5)) 
+            AND ( NOT 183 In (VAR6)) 
+            AND ( NOT 183 In (VAR7)) 
+            AND ( NOT 183 In (VAR8)) 
+            AND ( NOT 183 In (VAR9)) 
+            AND ( NOT 183 In (VAR10)) 
+            AND ( NOT 183 In (VAR11)) 
+            AND ( NOT 183 In (VAR12)) 
+            AND ( NOT 81 In (VAR4)) 
+            AND ( NOT 81 In (VAR5)) 
+            AND ( NOT 81 In (VAR6)) 
+            AND ( NOT 81 In (VAR7)) 
+            AND ( NOT 81 In (VAR8)) 
+            AND ( NOT 81 In (VAR9)) 
+            AND ( NOT 81 In (VAR10)) 
+            AND ( NOT 81 In (VAR11)) 
+            AND ( NOT 81 In (VAR12))
+        )
+    )
+) 
+AND 
+(
+    NOT 
+    (
+        (VAR1 > 0 
+        OR VAR2 > 0 
+        OR VAR3 > 0) 
+        AND 
+        (
+            ( 28 In (VAR4)) 
+            OR ( 28 In (VAR5)) 
+            OR ( 28 In (VAR6)) 
+            OR ( 28 In (VAR7)) 
+            OR ( 28 In (VAR8)) 
+            OR ( 28 In (VAR9)) 
+            OR ( 28 In (VAR10)) 
+            OR ( 28 In (VAR11)) 
+            OR ( 28 In (VAR12)) 
+            OR ( 24 In (VAR4)) 
+            OR ( 24 In (VAR5)) 
+            OR ( 24 In (VAR6)) 
+            OR ( 24 In (VAR7)) 
+            OR ( 24 In (VAR8)) 
+            OR ( 24 In (VAR9)) 
+            OR ( 24 In (VAR10)) 
+            OR ( 24 In (VAR11)) 
+            OR ( 24 In (VAR12)) 
+            OR ( 25 In (VAR4)) 
+            OR ( 25 In (VAR5)) 
+            OR ( 25 In (VAR6))
+            OR ( 25 In (VAR7)) 
+            OR ( 25 In (VAR8)) 
+            OR ( 25 In (VAR9)) 
+            OR ( 25 In (VAR10)) 
+            OR ( 25 In (VAR11)) 
+            OR ( 25 In (VAR12))
+        ) 
+        AND 
+        (
+            ( 44 In (VAR4)) 
+            OR ( 44 In (VAR5)) 
+            OR ( 44 In (VAR6)) 
+            OR ( 44 In (VAR7)) 
+            OR ( 44 In (VAR8)) 
+            OR ( 44 In (VAR9)) 
+            OR ( 44 In (VAR10)) 
+            OR ( 44 In (VAR11)) 
+            OR ( 44 In (VAR12))
+        )
+    )
+) 
+AND 
+( 
+    NOT 
+    (
+        (VAR1 > 0 
+        OR VAR2 > 0 
+        OR VAR3 > 0) 
+        AND 
+        (
+            ( NOT 28 In (VAR4)) 
+            AND ( NOT 28 In (VAR5)) 
+            AND ( NOT 28 In (VAR6)) 
+            AND ( NOT 28 In (VAR7)) 
+            AND ( NOT 28 In (VAR8)) 
+            AND ( NOT 28 In (VAR9)) 
+            AND ( NOT 28 In (VAR10)) 
+            AND ( NOT 28 In (VAR11)) 
+            AND ( NOT 28 In (VAR12)) 
+            AND ( NOT 24 In (VAR4)) 
+            AND ( NOT 24 In (VAR5)) 
+            AND ( NOT 24 In (VAR6)) 
+            AND ( NOT 24 In (VAR7)) 
+            AND ( NOT 24 In (VAR8)) 
+            AND ( NOT 24 In (VAR9)) 
+            AND ( NOT 24 In (VAR10)) 
+            AND ( NOT 24 In (VAR11)) 
+            AND ( NOT 24 In (VAR12)) 
+            AND ( NOT 25 In (VAR4)) 
+            AND ( NOT 25 In (VAR5)) 
+            AND ( NOT 25 In (VAR6)) 
+            AND ( NOT 25 In (VAR7)) 
+            AND ( NOT 25 In (VAR8)) 
+            AND ( NOT 25 In (VAR9)) 
+            AND ( NOT 25 In (VAR10)) 
+            AND ( NOT 25 In (VAR11)) 
+            AND ( NOT 25 In (VAR12))
+        ) 
+        AND 
+        (
+            ( 44 In (VAR4)) 
+            OR ( 44 In (VAR5)) 
+            OR ( 44 In (VAR6)) 
+            OR ( 44 In (VAR7)) 
+            OR ( 44 In (VAR8)) 
+            OR ( 44 In (VAR9)) 
+            OR ( 44 In (VAR10)) 
+            OR ( 44 In (VAR11)) 
+            OR ( 44 In (VAR12))
+        )
+    )
+) 
+AND 
+( 
+    NOT 
+    (
+        (VAR1 > 0 
+        OR VAR2 > 0 
+        OR VAR3 > 0) 
+        AND 
+        (
+            ( 28 In (VAR4)) 
+            OR ( 28 In (VAR5)) 
+            OR ( 28 In (VAR6)) 
+            OR ( 28 In (VAR7)) 
+            OR ( 28 In (VAR8)) 
+            OR ( 28 In (VAR9)) 
+            OR ( 28 In (VAR10)) 
+            OR ( 28 In (VAR11)) 
+            OR ( 28 In (VAR12)) 
+            OR ( 24 In (VAR4)) 
+            OR ( 24 In (VAR5)) 
+            OR ( 24 In (VAR6)) 
+            OR ( 24 In (VAR7)) 
+            OR ( 24 In (VAR8)) 
+            OR ( 24 In (VAR9)) 
+            OR ( 24 In (VAR10)) 
+            OR ( 24 In (VAR11)) 
+            OR ( 24 In (VAR12)) 
+            OR ( 25 In (VAR4)) 
+            OR ( 25 In (VAR5)) 
+            OR ( 25 In (VAR6)) 
+            OR ( 25 In (VAR7)) 
+            OR ( 25 In (VAR8)) 
+            OR ( 25 In (VAR9)) 
+            OR ( 25 In (VAR10)) 
+            OR ( 25 In (VAR11)) 
+            OR ( 25 In (VAR12))
+        ) 
+        AND 
+        (
+            ( 34 In (VAR4)) 
+            OR ( 34 In (VAR5)) 
+            OR ( 34 In (VAR6)) 
+            OR ( 34 In (VAR7)) 
+            OR ( 34 In (VAR8)) 
+            OR ( 34 In (VAR9)) 
+            OR ( 34 In (VAR10)) 
+            OR ( 34 In (VAR11)) 
+            OR ( 34 In (VAR12))
+        )
+    )
+) 
+AND 
+( 
+    NOT 
+    (
+        (VAR1 > 0 
+        OR VAR2 > 0 
+        OR VAR3 > 0) 
+        AND 
+        (
+            ( NOT 28 In (VAR4)) 
+            AND ( NOT 28 In (VAR5)) 
+            AND ( NOT 28 In (VAR6)) 
+            AND ( NOT 28 In (VAR7)) 
+            AND ( NOT 28 In (VAR8)) 
+            AND ( NOT 28 In (VAR9)) 
+            AND ( NOT 28 In (VAR10)) 
+            AND ( NOT 28 In (VAR11)) 
+            AND ( NOT 28 In (VAR12)) 
+            AND ( NOT 24 In (VAR4)) 
+            AND ( NOT 24 In (VAR5)) 
+            AND ( NOT 24 In (VAR6)) 
+            AND ( NOT 24 In (VAR7)) 
+            AND ( NOT 24 In (VAR8)) 
+            AND ( NOT 24 In (VAR9)) 
+            AND ( NOT 24 In (VAR10)) 
+            AND ( NOT 24 In (VAR11)) 
+            AND ( NOT 24 In (VAR12)) 
+            AND ( NOT 25 In (VAR4)) 
+            AND ( NOT 25 In (VAR5)) 
+            AND ( NOT 25 In (VAR6)) 
+            AND ( NOT 25 In (VAR7)) 
+            AND ( NOT 25 In (VAR8)) 
+            AND ( NOT 25 In (VAR9)) 
+            AND ( NOT 25 In (VAR10)) 
+            AND ( NOT 25 In (VAR11)) 
+            AND ( NOT 25 In (VAR12))
+        ) 
+        AND 
+        (
+            ( 34 In (VAR4)) 
+            OR ( 34 In (VAR5)) 
+            OR ( 34 In (VAR6)) 
+            OR ( 34 In (VAR7)) 
+            OR ( 34 In (VAR8)) 
+            OR ( 34 In (VAR9)) 
+            OR ( 34 In (VAR10)) 
+            OR ( 34 In (VAR11)) 
+            OR ( 34 In (VAR12))
+        )
+    )
+) 
+AND 
+( 
+    NOT 
+    (
+        (VAR1 > 0 
+        OR VAR2 > 0 
+        OR VAR3 > 0) 
+        AND 
+        (
+            ( 28 In (VAR4)) 
+            OR ( 28 In (VAR5)) 
+            OR ( 28 In (VAR6)) 
+            OR ( 28 In (VAR7)) 
+            OR ( 28 In (VAR8)) 
+            OR ( 28 In (VAR9)) 
+            OR ( 28 In (VAR10)) 
+            OR ( 28 In (VAR11)) 
+            OR ( 28 In (VAR12)) 
+            OR ( 24 In (VAR4)) 
+            OR ( 24 In (VAR5)) 
+            OR ( 24 In (VAR6)) 
+            OR ( 24 In (VAR7)) 
+            OR ( 24 In (VAR8)) 
+            OR ( 24 In (VAR9)) 
+            OR ( 24 In (VAR10)) 
+            OR ( 24 In (VAR11)) 
+            OR ( 24 In (VAR12)) 
+            OR ( 25 In (VAR4)) 
+            OR ( 25 In (VAR5)) 
+            OR ( 25 In (VAR6)) 
+            OR ( 25 In (VAR7)) 
+            OR ( 25 In (VAR8)) 
+            OR ( 25 In (VAR9)) 
+            OR ( 25 In (VAR10)) 
+            OR ( 25 In (VAR11)) 
+            OR ( 25 In (VAR12))
+        ) 
+        AND 
+        (
+            ( 81 In (VAR4)) 
+            OR ( 81 In (VAR5)) 
+            OR ( 81 In (VAR6)) 
+            OR ( 81 In (VAR7)) 
+            OR ( 81 In (VAR8)) 
+            OR ( 81 In (VAR9)) 
+            OR ( 81 In (VAR10)) 
+            OR ( 81 In (VAR11)) 
+            OR ( 81 In (VAR12)) 
+            OR ( 183 In (VAR4)) 
+            OR ( 183 In (VAR5)) 
+            OR ( 183 In (VAR6)) 
+            OR ( 183 In (VAR7)) 
+            OR ( 183 In (VAR8)) 
+            OR ( 183 In (VAR9)) 
+            OR ( 183 In (VAR10)) 
+            OR ( 183 In (VAR11)) 
+            OR ( 183 In (VAR12))
+        )
+    )
+) 
+AND 
+( 
+    NOT 
+    (
+        (VAR1 > 0 
+        OR VAR2 > 0 
+        OR VAR3 > 0) 
+        AND 
+        (
+            ( NOT 28 In (VAR4)) 
+            AND ( NOT 28 In (VAR5)) 
+            AND ( NOT 28 In (VAR6)) 
+            AND ( NOT 28 In (VAR7)) 
+            AND ( NOT 28 In (VAR8)) 
+            AND ( NOT 28 In (VAR9)) 
+            AND ( NOT 28 In (VAR10)) 
+            AND ( NOT 28 In (VAR11)) 
+            AND ( NOT 28 In (VAR12)) 
+            AND ( NOT 24 In (VAR4)) 
+            AND ( NOT 24 In (VAR5)) 
+            AND ( NOT 24 In (VAR6)) 
+            AND ( NOT 24 In (VAR7)) 
+            AND ( NOT 24 In (VAR8)) 
+            AND ( NOT 24 In (VAR9)) 
+            AND ( NOT 24 In (VAR10)) 
+            AND ( NOT 24 In (VAR11)) 
+            AND ( NOT 24 In (VAR12)) 
+            AND ( NOT 25 In (VAR4)) 
+            AND ( NOT 25 In (VAR5)) 
+            AND ( NOT 25 In (VAR6)) 
+            AND ( NOT 25 In (VAR7)) 
+            AND ( NOT 25 In (VAR8)) 
+            AND ( NOT 25 In (VAR9)) 
+            AND ( NOT 25 In (VAR10)) 
+            AND ( NOT 25 In (VAR11)) 
+            AND ( NOT 25 In (VAR12))
+        ) 
+        AND 
+        (
+            ( 81 In (VAR4)) 
+            OR ( 81 In (VAR5)) 
+            OR ( 81 In (VAR6)) 
+            OR ( 81 In (VAR7)) 
+            OR ( 81 In (VAR8)) 
+            OR ( 81 In (VAR9)) 
+            OR ( 81 In (VAR10)) 
+            OR ( 81 In (VAR11)) 
+            OR ( 81 In (VAR12)) 
+            OR ( 183 In (VAR4)) 
+            OR ( 183 In (VAR5)) 
+            OR ( 183 In (VAR6)) 
+            OR ( 183 In (VAR7)) 
+            OR ( 183 In (VAR8)) 
+            OR ( 183 In (VAR9)) 
+            OR ( 183 In (VAR10)) 
+            OR ( 183 In (VAR11)) 
+            OR ( 183 In (VAR12))
+        )
+    )
+) 
+AND NOT 
+(
+    ( 174 In (VAR13)) 
+    OR ( 174 In (VAR14)) 
+    OR ( 174 In (VAR15)) 
+    OR ( 174 In (VAR16)) 
+    OR ( 174 In (VAR17)) 
+    OR ( 174 In (VAR18)) 
+    OR ( 174 In (VAR19)) 
+    OR ( 174 In (VAR20)) 
+    OR ( 174 In (VAR21)) 
+    OR ( 174 In (VAR22)) 
+    OR ( 174 In (VAR23)) 
+    OR ( 174 In (VAR24)) 
+    OR ( 174 In (VAR25)) 
+    OR ( 174 In (VAR26)) 
+    OR ( 174 In (VAR27)) 
+    OR ( 174 In (VAR28)) 
+    OR ( 174 In (VAR29)) 
+    OR ( 174 In (VAR30)) 
+    OR ( 306 In (VAR13)) 
+    OR ( 306 In (VAR14)) 
+    OR ( 306 In (VAR15)) 
+    OR ( 306 In (VAR16)) 
+    OR ( 306 In (VAR17)) 
+    OR ( 306 In (VAR18)) 
+    OR ( 306 In (VAR19)) 
+    OR ( 306 In (VAR20)) 
+    OR ( 306 In (VAR21)) 
+    OR ( 306 In (VAR22)) 
+    OR ( 306 In (VAR23)) 
+    OR ( 306 In (VAR24)) 
+    OR ( 306 In (VAR25)) 
+    OR ( 306 In (VAR26)) 
+    OR ( 306 In (VAR27)) 
+    OR ( 306 In (VAR28)) 
+    OR ( 306 In (VAR29)) 
+    OR ( 306 In (VAR30)) 
+    OR ( 492 In (VAR13)) 
+    OR ( 492 In (VAR14)) 
+    OR ( 492 In (VAR15)) 
+    OR ( 492 In (VAR16)) 
+    OR ( 492 In (VAR17)) 
+    OR ( 492 In (VAR18)) 
+    OR ( 492 In (VAR19)) 
+    OR ( 492 In (VAR20))
+    OR ( 492 In (VAR21)) 
+    OR ( 492 In (VAR22)) 
+    OR ( 492 In (VAR23)) 
+    OR ( 492 In (VAR24)) 
+    OR ( 492 In (VAR25)) 
+    OR ( 492 In (VAR26)) 
+    OR ( 492 In (VAR27)) 
+    OR ( 492 In (VAR28)) 
+    OR ( 492 In (VAR29)) 
+    OR ( 492 In (VAR30))
+)";
+        private const String SmallExpression = "(4 ^ 3.4 * 18 - VAR1) * (14 / 3) + VAR2";
+        private const String SmallBranching = "If(If(23 > 15 AND 3*7 = 21 OR (25/5 > 10 AND 6+8 = 14), If(2.1=2.1,(4 ^ 3.4 * 18 - VAR1),If(2.1=2.1,0,1)), (14 / 3) + VAR2) <> 0 or true, If(2.1 <> 2.1 AND 3.1=3.1 OF 6.2=6.7, 2.1, 3.1), If(2.1=2.1 AND 3.2=3.2 OR 3.1<>3.1 OR 2.1<>2.3,3, 4))";
+
+        [Test(Description = "Compile complicated expressions")]
+        public void ProfileCompilationTime()
+        {
+            int expectedTime = 1000;
+            int iterations = 10;
+
+            var context = new ExpressionContext();
+            context.Variables.ResolveVariableType += Variables_ResolveVariableType;
+            context.Variables.ResolveVariableValue += Variables_ResolveVariableValue;
+            Stopwatch sw;
+
+            /*
+            sw = new Stopwatch();
+            sw.Start();
+
+            for (int i = 0; i < iterations - 1; i++)
+            {
+                IDynamicExpression e = this.CreateDynamicExpression(BigExpression, context);
+
+            }
+            sw.Stop();
+            this.PrintSpeedMessage("Compile Big", iterations, sw);
+            Assert.Less(sw.ElapsedMilliseconds, expectedTime, "Test time above expected value");
+            */
+
+            iterations = 100;
+            expectedTime = 100;
+
+            sw = new Stopwatch();
+            sw.Start();
+
+            for (int i = 0; i < iterations - 1; i++)
+            {
+                IDynamicExpression e = this.CreateDynamicExpression(SmallExpression, context);
+
+            }
+            sw.Stop();
+            this.PrintSpeedMessage("Compile Small", iterations, sw);
+            Assert.Less(sw.ElapsedMilliseconds, expectedTime, "Test time above expected value");
+
+            iterations = 100;
+            expectedTime = 100;
+
+            sw = new Stopwatch();
+            sw.Start();
+
+            for (int i = 0; i < iterations - 1; i++)
+            {
+                IDynamicExpression e = this.CreateDynamicExpression(SmallExpression, context);
+
+            }
+            sw.Stop();
+            this.PrintSpeedMessage("Compile Small Branching", iterations, sw);
+            Assert.Less(sw.ElapsedMilliseconds, expectedTime, "Test time above expected value");
+        }
+
+
+        private static void Variables_ResolveVariableType(object sender, ResolveVariableTypeEventArgs e)
+        {
+            if (e.VariableName.StartsWith("VARBOOL"))
+            {
+                e.VariableType = typeof(bool);
+            }
+            else
+            {
+                e.VariableType = typeof(int);
+            }
+        }
+
+        private static void Variables_ResolveVariableValue(object sender, ResolveVariableValueEventArgs e)
+        {
+            if (e.VariableType == typeof(bool))
+            {
+                e.VariableValue = false;
+            }
+            else
+            {
+                e.VariableValue = 0;
+            }
+        }
+
         private void PrintSpeedMessage(string title, int iterations, Stopwatch sw)
         {
-            this.WriteMessage("{0}: {1:n0} iterations in {2:n2}ms = {3:n2} iterations/sec", title, iterations, sw.ElapsedMilliseconds, iterations / (sw.ElapsedMilliseconds / 10));
+            this.WriteMessage("{0}: {1:n0} iterations in {2:n2}ms = {3:n2} iterations/sec", title, iterations, sw.ElapsedMilliseconds, iterations*1000 / (sw.ElapsedMilliseconds));
         }
     }
 }

--- a/test/Flee.Test/ExpressionTests/Benchmarks.cs
+++ b/test/Flee.Test/ExpressionTests/Benchmarks.cs
@@ -591,7 +591,7 @@ AND NOT
             context.Variables.ResolveVariableValue += Variables_ResolveVariableValue;
             Stopwatch sw;
 
-            /*
+            
             sw = new Stopwatch();
             sw.Start();
 
@@ -603,7 +603,7 @@ AND NOT
             sw.Stop();
             this.PrintSpeedMessage("Compile Big", iterations, sw);
             Assert.Less(sw.ElapsedMilliseconds, expectedTime, "Test time above expected value");
-            */
+            
 
             iterations = 100;
             expectedTime = 100;

--- a/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
+++ b/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
@@ -77,5 +77,18 @@ namespace ExpressionBuildingTest
 
             Assert.IsTrue((bool)e1.Evaluate());
         }
+
+        [TestMethod]
+        public void CompareLongs()
+        {
+            // bug #83 test.
+            ExpressionContext context = new ExpressionContext();
+            IDynamicExpression e1 = context.CompileDynamic("2432696330L = 2432696330L AND 2432696330L > 0 AND 2432696330L < 2432696331L");
+
+            Assert.IsTrue((bool)e1.Evaluate());
+            e1 = context.CompileDynamic("2432696330L / 2");
+
+            Assert.AreEqual(1216348165L, e1.Evaluate());
+        }
     }
 }

--- a/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
+++ b/test/Flee.Test/ExpressionTests/ExpressionBuildingTest.cs
@@ -90,5 +90,32 @@ namespace ExpressionBuildingTest
 
             Assert.AreEqual(1216348165L, e1.Evaluate());
         }
+
+        [TestMethod]
+        public void ArgumentInt_to_DoubleConversion()
+        {
+            ExpressionContext context = new ExpressionContext();
+            context.Imports.AddType(typeof(Math));
+            IDynamicExpression e1 = context.CompileDynamic("sqrt(16)");
+
+            Assert.AreEqual(4.0, e1.Evaluate());
+        }
+
+
+        [TestMethod]
+        public void IN_OperatorTest()
+        {
+            ExpressionContext context = new ExpressionContext();
+            var e1 = context.CompileGeneric<bool>("NOT 15 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,16,17,18,19,20,21,22,23)");
+
+            Assert.IsTrue(e1.Evaluate());
+
+            e1 = context.CompileGeneric<bool>("\"a\" IN (\"a\",\"b\",\"c\",\"d\") and true and 5 in (2,4,5)");
+            Assert.IsTrue(e1.Evaluate());
+            e1 = context.CompileGeneric<bool>("\"a\" IN (\"a\",\"b\",\"c\",\"d\") and true and 5 in (2,4,6,7,8,9)");
+            Assert.IsFalse(e1.Evaluate());
+        }
+
+
     }
 }

--- a/test/Flee.Test/ExtensionMethodTests/ExtensionMethodTest.cs
+++ b/test/Flee.Test/ExtensionMethodTests/ExtensionMethodTest.cs
@@ -65,6 +65,23 @@
             Assert.AreEqual("Hello SubWorld!!!", result);
         }
 
+        /// <summary>
+        /// check that methods are not ambiguous.
+        /// </summary>
+        [TestMethod]
+        public void TestExtensionMethodMatchArguments()
+        {
+            var result = GetExpressionContext().CompileDynamic("MatchParams(1, 2.3f, 2.3)").Evaluate();
+            Assert.AreEqual("FFD", result);
+            result = GetExpressionContext().CompileDynamic("MatchParams(3.4,4.4,2.3)").Evaluate();
+            Assert.AreEqual("DDD", result);
+            result = GetExpressionContext().CompileDynamic("MatchParams(1,2,3)").Evaluate();
+            Assert.AreEqual("III", result);
+            result = GetExpressionContext().CompileDynamic("MatchParams(1u,2,3)").Evaluate();
+            Assert.AreEqual("UII", result);
+        }
+
+
         private static ExpressionContext GetExpressionContext()
         {
             var expressionOwner = new TestData { Id = "World" };

--- a/test/Flee.Test/ExtensionMethodTests/TestData.cs
+++ b/test/Flee.Test/ExtensionMethodTests/TestData.cs
@@ -21,5 +21,31 @@
 
             return result + Id;
         }
+
+        /// <summary>
+        /// A bug previous meant a small difference in
+        /// parameters was not detected and treated
+        /// as ambiguous
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
+        /// <returns></returns>
+        public string MatchParams(uint x, int y, int z)
+        {
+            return "UII";
+        }
+        public string MatchParams(int x, int y, int z)
+        {
+            return "III";
+        }
+        public string MatchParams(float x, float y, double z)
+        {
+            return "FFD";
+        }
+        public string MatchParams(double x, double y, double z)
+        {
+            return "DDD";
+        }
     }
 }

--- a/test/Flee.Test/Flee.Test.csproj
+++ b/test/Flee.Test/Flee.Test.csproj
@@ -39,9 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flee.Net45, Version=1.0.0.0, Culture=neutral, PublicKeyToken=951a102ce2413032, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flee.1.2.1\lib\net45\Flee.Net45.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -72,6 +69,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="TestScripts\NestedConditionals.js" />
     <Content Include="TestScripts\readme.txt" />
     <Content Include="TestScripts\CheckedTests.txt" />
     <Content Include="TestScripts\IndividualTests.xml" />
@@ -82,6 +80,12 @@
     <Content Include="TestScripts\SimpleCalcEngineTests.txt" />
     <Content Include="TestScripts\ValidCasts.txt" />
     <Content Include="TestScripts\ValidExpressions.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Flee.Net45\Flee.Net45.csproj">
+      <Project>{658c0ed4-404a-48ec-96ff-d22c3c12ac39}</Project>
+      <Name>Flee.Net45</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/Flee.Test/Flee.Test.csproj
+++ b/test/Flee.Test/Flee.Test.csproj
@@ -69,7 +69,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="TestScripts\NestedConditionals.js" />
     <Content Include="TestScripts\readme.txt" />
     <Content Include="TestScripts\CheckedTests.txt" />
     <Content Include="TestScripts\IndividualTests.xml" />

--- a/test/Flee.Test/Flee.Test.csproj
+++ b/test/Flee.Test/Flee.Test.csproj
@@ -81,9 +81,9 @@
     <Content Include="TestScripts\ValidExpressions.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Flee.Net45\Flee.Net45.csproj">
-      <Project>{658c0ed4-404a-48ec-96ff-d22c3c12ac39}</Project>
-      <Name>Flee.Net45</Name>
+    <ProjectReference Include="..\..\src\Flee.NetStandard20\Flee.NetStandard20.csproj">
+      <Project>{8c600bab-128a-4792-8260-469b2dad6681}</Project>
+      <Name>Flee.NetStandard20</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/test/Flee.Test/packages.config
+++ b/test/Flee.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flee" version="1.2.1" targetFramework="net461" />
+  <package id="Flee" version="1.2.2" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="1.1.11" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.1.11" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />


### PR DESCRIPTION
Bug #86 exposes a bug in Flee where nested long branches are not handled.

When generating nested expressions, a "temp" generator is used. This is done to determine where the branches are and how long they should be, but nested expressions don't adjust for long branches when the generator is in temp mode, since the isTemp flag forces short branches even when it compiles twice.

When in temp compiling mode, the actual branches don't matter on the nested code, just the final offet, so instead of compiling twice to adjust for long branches, the nested expressions only need to add a few NOPs so that the proper offsets can be found by the calling frame of reference.  Thus ComputeBranches now emits NOP to make the generated code the proper size.

A more elegant solution may be to have a single BranchManager for the entire expression, shared by all nested conditionals/IN/AndOr/etc.  In that case, the entire expression would only be compiled twice, rather than multiple times. However, the ComputeBranches method would need to be changed as it also doesn't handle nested branches properly (at a minimum, needs to start with last branch and move backward)

