### PR TITLE
Support for .NET 9 and .NET 10

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# Flee (Supports Net6.0, Net5.0, Netstandard2.1, Netstandard2.0)
+# Flee
  Fast Lightweight Expression Evaluator.
  Convert this project vb.net to c#.
   

--- a/src/Flee/Flee.csproj
+++ b/src/Flee/Flee.csproj
@@ -8,7 +8,7 @@
         <Authors>Flee Contributors</Authors>
         <Company>Flee</Company>
         <Product>Flee</Product>
-        <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/src/Flee/Flee.csproj
+++ b/src/Flee/Flee.csproj
@@ -8,7 +8,7 @@
         <Authors>Flee Contributors</Authors>
         <Company>Flee</Company>
         <Product>Flee</Product>
-        <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/src/Flee/InternalTypes/FleeILGenerator.cs
+++ b/src/Flee/InternalTypes/FleeILGenerator.cs
@@ -264,6 +264,6 @@ namespace Flee.InternalTypes
 
         public int LabelCount => _myLabelCount;
 
-        private int ILGeneratorLength => Utility.GetILGeneratorLength(_myIlGenerator);
+        private int ILGeneratorLength => _myIlGenerator.ILOffset;
     }
 }

--- a/src/Flee/InternalTypes/Utility.cs
+++ b/src/Flee/InternalTypes/Utility.cs
@@ -318,12 +318,6 @@ namespace Flee.InternalTypes
             return null;
         }
 
-        public static int GetILGeneratorLength(ILGenerator ilg)
-        {
-            System.Reflection.FieldInfo fi = typeof(ILGenerator).GetField("m_length", BindingFlags.Instance | BindingFlags.NonPublic);
-            return (int)fi.GetValue(ilg);
-        }
-
         public static bool IsLongBranch(int startPosition, int endPosition)
         {
             return (endPosition - startPosition) > sbyte.MaxValue;

--- a/test/Flee.Test/Flee.Test.csproj
+++ b/test/Flee.Test/Flee.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
This PR includes the build targets for .NET 9 and .NET 10.

Based on the previous PR (#115), which adds support for .NET 8 and includes fixes.